### PR TITLE
cscope: permit non-word tokens to occur in end table

### DIFF
--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -241,7 +241,7 @@ END
 
           key = record[:name][-1].to_s
           if key =~ /^\W*$/
-            next unless record[:tbl] == :defs
+            next unless [:defs, :end].include?(record[:tbl])
           else
             key.sub!(/\W+$/, '')
           end


### PR DESCRIPTION
Go (and many other languages) end blocks with "}" which was otherwise not
getting tokenized at all since it contained only non-word characters.

Fixes #54
