### PR TITLE
Move more export logic into the export module

### DIFF
--- a/bin/starscope
+++ b/bin/starscope
@@ -8,8 +8,6 @@ require 'readline'
 require 'starscope'
 
 DEFAULT_DB='.starscope.db'
-DEFAULT_CTAGS='tags'
-DEFAULT_CSCOPE='cscope.out'
 
 options = {:read => true,
            :write => true,
@@ -94,8 +92,8 @@ END
   opts.separator <<END
 \nEXPORTING
     At the moment two export formats are supported: 'ctags' and 'cscope'. If
-    you don't specify a path, the output is written to the file '#{DEFAULT_CTAGS}' (for
-    ctags) or '#{DEFAULT_CSCOPE}' (for cscope) in the current directory.
+    you don't specify a path, the output is written to the file '#{Starscope::Export::CTAGS_DEFAULT_PATH}' (for
+    ctags) or '#{Starscope::Export::CSCOPE_DEFAULT_PATH}' (for cscope) in the current directory.
 END
 
 end.parse!
@@ -141,25 +139,11 @@ rescue Starscope::DB::NoTableError
   return false
 end
 
-def export(db, param, output)
+def export(db, param)
   format, path = param.split(',', 2)
-
-  case format
-  when 'ctags'; path ||= DEFAULT_CTAGS
-  when 'cscope'; path ||= DEFAULT_CSCOPE
-  else
-    $stderr.puts "Unrecognized export format \"#{format}\""
-    return
-  end
-
-  output.normal("Exporting to '#{path}' in format '#{format}'...")
-  File.open(path, 'w') do |file|
-    case format
-    when 'ctags'; db.export_ctags(file)
-    when 'cscope'; db.export_cscope(file)
-    end
-  end
-  output.normal("Export complete.")
+  db.export(format, path)
+rescue Starscope::Export::UnknownExportFormatError
+  $stderr.puts "Unrecognized export format \"#{format}\""
 end
 
 output = Starscope::Output.new(options[:output])
@@ -195,7 +179,7 @@ new_data ||= updated
 
 db.save(options[:db]) if options[:write] && (new_data || !db_exists)
 
-options[:export].each { |target| export(db, target, output) }
+options[:export].each { |target| export(db, target) }
 
 if options[:query]
   table, query = options[:query].split(',', 2)
@@ -239,7 +223,7 @@ if options[:linemode]
           dump(db, param)
         when "export"
           if param
-            export(db, param, output)
+            export(db, param)
           else
             puts "!export requires an argument"
           end

--- a/lib/starscope/export.rb
+++ b/lib/starscope/export.rb
@@ -1,5 +1,32 @@
 module Starscope::Export
 
+  CTAGS_DEFAULT_PATH='tags'
+  CSCOPE_DEFAULT_PATH='cscope.out'
+
+  class UnknownExportFormatError < StandardError; end
+
+  def export(format, path=nil)
+    case format
+    when 'ctags'
+      path ||= CTAGS_DEFAULT_PATH
+    when 'cscope'
+      path ||= CSCOPE_DEFAULT_PATH
+    else
+      raise UnknownExportFormatError
+    end
+
+    @output.normal("Exporting to '#{path}' in format '#{format}'...")
+    File.open(path, 'w') do |file|
+      case format
+      when 'ctags'; export_ctags(file)
+      when 'cscope'; export_cscope(file)
+      end
+    end
+    @output.normal("Export complete.")
+  end
+
+  private
+
   # cscope has this funky issue where it refuses to recognize function calls that
   # happen outside of a function definition - this isn't an issue in C, where all
   # calls must occur in a function, but in ruby et al. it is perfectly legal to
@@ -89,8 +116,6 @@ END
     files.each {|f| buf << f + "\n"}
     file.print("#{buf.length}\n#{buf}")
   end
-
-  private
 
   def db_by_line()
     db = {}

--- a/test/unit/db_test.rb
+++ b/test/unit/db_test.rb
@@ -99,43 +99,6 @@ describe Starscope::DB do
     end
   end
 
-  it "must export to ctags" do
-    file = Tempfile.new('starscope_test')
-    begin
-      @db.add_paths(["#{FIXTURES}"])
-      @db.export_ctags(file)
-      file.rewind
-      lines = file.lines.to_a
-      lines.must_include "NoTableError\t#{FIXTURES}/sample_ruby.rb\t/^  class NoTableError < StandardError; end$/;\"\tkind:c\tlanguage:Ruby\n"
-    ensure
-      file.close
-      file.unlink
-    end
-  end
-
-  it "must export to cscope" do
-    file = Tempfile.new('starscope_test')
-    begin
-      @db.add_paths(["#{FIXTURES}"])
-      @db.export_cscope(file)
-      file.rewind
-      lines = file.lines.to_a
-
-      lines.must_include "\t@#{FIXTURES}/sample_golang.go\n"
-      lines.must_include "\tgSunday\n"
-      lines.must_include "\t`add_file\n"
-      lines.must_include "\t}}\n"
-      lines.must_include "13 class \n"
-
-      lines.wont_include "= [\n"
-      lines.wont_include "4 LANGS = [\n"
-      lines.wont_include "116 tmpdb[entry[:file]][entry[:line_no]] ||= []\n"
-    ensure
-      file.close
-      file.unlink
-    end
-  end
-
   it "must run queries" do
     @db.add_paths(["#{FIXTURES}"])
     @db.query(:calls, "abc").must_equal []

--- a/test/unit/export_test.rb
+++ b/test/unit/export_test.rb
@@ -1,0 +1,34 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+describe Starscope::Export do
+
+  before do
+    @db = Starscope::DB.new(Starscope::Output.new(:quiet))
+    @db.add_paths(["#{FIXTURES}"])
+    @buf = StringIO.new
+  end
+
+  it "must export to ctags" do
+    @db.send(:export_ctags, @buf)
+    @buf.rewind
+    lines = @buf.lines.to_a
+    lines.must_include "NoTableError\t#{FIXTURES}/sample_ruby.rb\t/^  class NoTableError < StandardError; end$/;\"\tkind:c\tlanguage:Ruby\n"
+  end
+
+  it "must export to cscope" do
+    @db.send(:export_cscope, @buf)
+    @buf.rewind
+    lines = @buf.lines.to_a
+
+    lines.must_include "\t@#{FIXTURES}/sample_golang.go\n"
+    lines.must_include "\tgSunday\n"
+    lines.must_include "\t`add_file\n"
+    lines.must_include "\t}}\n"
+    lines.must_include "13 class \n"
+
+    lines.wont_include "= [\n"
+    lines.wont_include "4 LANGS = [\n"
+    lines.wont_include "116 tmpdb[entry[:file]][entry[:line_no]] ||= []\n"
+  end
+
+end


### PR DESCRIPTION
Also split the export tests out of the normal DB tests into their own file, and
use StringIO instead of the Tempfile hack.

Part of #82
