### PR TITLE
ruby: add `reads` and `sym` tables

### DIFF
--- a/doc/LANGUAGE_SUPPORT.md
+++ b/doc/LANGUAGE_SUPPORT.md
@@ -61,6 +61,8 @@ belongs (basically its type). Current tables already include:
  * `assigns` for variable assignment
  * `requires` for required files in Ruby
  * `imports` for imported packages in Golang
+ * `reads` for reading of variables, constants etc. (e.g. use in an expression)
+ * `sym` for Ruby symbols
 
 Try to use pre-existing tables where possible, but feel free to add more if the
 language has some weird feature that doesn't map to any of the above. You don't

--- a/lib/starscope/langs/ruby.rb
+++ b/lib/starscope/langs/ruby.rb
@@ -66,12 +66,22 @@ module Starscope::Lang
         yield :end, :end, :line_no => loc.end.line, :type => node.type, :col => loc.end.column
 
       when :casgn
-        fqn = scoped_name(node, scope)
-        yield :assigns, fqn, :line_no => loc.line, :col => loc.name.column
-        yield :defs, fqn, :line_no => loc.line, :col => loc.name.column
+        name = scoped_name(node, scope)
+        yield :assigns, name, :line_no => loc.line, :col => loc.name.column
+        yield :defs, name, :line_no => loc.line, :col => loc.name.column
 
       when :lvasgn, :ivasgn, :cvasgn, :gvasgn
         yield :assigns, scope + [node.children[0]], :line_no => loc.line, :col => loc.name.column
+
+      when :const
+        name = scoped_name(node, scope)
+        yield :reads, name, :line_no => loc.line, :col => loc.name.column
+
+      when :lvar, :ivar, :cvar, :gvar
+        yield :reads, scope + [node.children[0]], :line_no => loc.line, :col => loc.expression.column
+
+      when :sym
+        yield :sym, [node.children[0]], :line_no => loc.line, :col => loc.expression.column
       end
     end
 

--- a/test/functional/starscope_test.rb
+++ b/test/functional/starscope_test.rb
@@ -17,7 +17,7 @@ describe "starscope executable script" do
 
   it "must produce a valid database summary" do
     lines = `#{EXTRACT} -s`.lines.to_a
-    lines.length.must_equal 6
+    lines.length.must_equal 8
   end
 
   it "must produce a valid database dump" do


### PR DESCRIPTION
for reading of variables/constants, and for uses of symbols, respectively

they should automatically get put into cscope output as unmarked symbols,
implementing another part of #60