### PR TITLE
fix logic inversion in upconvert writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ New Features:
 Bug Fixes:
  * Simplify query logic to match user expectations (#91)
  * Cscope: fix export of inline function definitions.
+ * DB: fix saving of upconverted databases in rare circumstances.
 
 v1.2.0 (2014-09-02)
 --------------------

--- a/bin/starscope
+++ b/bin/starscope
@@ -193,7 +193,8 @@ db = Starscope::DB.new(output)
 db_exists = File.exists?(options[:db])
 
 if options[:read] && db_exists
-  new_data = db.load(options[:db])
+  # we consider it 'new data' if the db was upconverted from an old format
+  new_data = !db.load(options[:db])
 else
   # no need to run an update if we didn't read any old data
   options[:update] = false

--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -36,6 +36,7 @@ class Starscope::DB
     @tables = {}
   end
 
+  # returns true iff the database was already in the most recent format
   def load(filename)
     @output.extra("Reading database from `#{filename}`... ")
     current_fmt = open_db(filename)


### PR DESCRIPTION
Upconverted DBs might not have been written if there were no other changes, and
unnecessary writing could have happened.