### PR TITLE
ctags: escape '/' characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 v1.3.3 (trunk)
 --------------------
 
+Bug Fixes:
+ * Escape '/' characters in the line 'pattern' component of ctags records, since
+   otherwise they terminate that component when it is read as a vim search
+   command.
+
 Improvements:
  * Recognize rake tasks as ruby files.
 

--- a/lib/starscope/exportable.rb
+++ b/lib/starscope/exportable.rb
@@ -51,7 +51,8 @@ END
   end
 
   def ctag_line(rec, file)
-    ret = "#{rec[:name][-1]}\t#{rec[:file]}\t/^#{line_for_record(rec)}$/"
+    line = line_for_record(rec).gsub('/', '\/')
+    ret = "#{rec[:name][-1]}\t#{rec[:file]}\t/^#{line}$/"
 
     ext = ctag_ext_tags(rec, file)
     if not ext.empty?


### PR DESCRIPTION
Escape '/' characters in the line 'pattern' component of ctags records, since
otherwise they terminate that component when it is read as a vim search command.