### PR TITLE
Change the signature of `extract`

### DIFF
--- a/doc/LANGUAGE_SUPPORT.md
+++ b/doc/LANGUAGE_SUPPORT.md
@@ -28,7 +28,7 @@ module Starscope::Lang
       name.end_with?(".mylang")
     end
 
-    def self.extract(file)
+    def self.extract(path, contents)
       # TODO
     end
   end
@@ -45,9 +45,10 @@ methods:
    written in MyLanguage or not. This can be as simple as checking the file
    extension (which the sample code does) or looking for a shell #! line, or
    anything you want.
- * `extract` takes a readable file handle pointing to the file, and must parse
-   the file, `yield`ing records as it finds function definitions and the like.
-   It may also return a final hash of file-wide metadata to store.
+ * `extract` takes the path to the file and a string containing the contents of
+   the file, and must parse the text, `yield`ing records as it finds function
+   definitions and the like. It may also return a final hash of file-wide
+   metadata to store.
 
 The record requirements are pretty straight-forward:
 ```ruby

--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -255,7 +255,7 @@ class Starscope::DB
     lines = nil
     line_cache = nil
 
-    extractor_metadata = extractor.extract(file) do |tbl, name, args|
+    extractor_metadata = extractor.extract(file, File.read(file)) do |tbl, name, args|
       raise NoTableError if tbl.to_s.start_with?('!')
       @tables[tbl] ||= []
       @tables[tbl] << self.class.normalize_record(file, name, args)

--- a/lib/starscope/langs/go.rb
+++ b/lib/starscope/langs/go.rb
@@ -13,10 +13,10 @@ module Starscope::Lang
       name.end_with?('.go')
     end
 
-    def self.extract(file, &block)
+    def self.extract(path, contents, &block)
       stack = []
       scope = []
-      File.readlines(file).each_with_index do |line, line_no|
+      contents.lines.each_with_index do |line, line_no|
         line_no += 1 # zero-index to one-index
 
         # strip single-line comments like // foo

--- a/lib/starscope/langs/ruby.rb
+++ b/lib/starscope/langs/ruby.rb
@@ -13,8 +13,8 @@ module Starscope::Lang
       end
     end
 
-    def self.extract(file, &block)
-      ast = Parser::CurrentRuby.parse_file(file)
+    def self.extract(path, contents, &block)
+      ast = Parser::CurrentRuby.parse(contents)
       extract_tree(ast, [], &block) unless ast.nil?
     end
 

--- a/test/unit/db_test.rb
+++ b/test/unit/db_test.rb
@@ -130,7 +130,7 @@ describe Starscope::DB do
   it 'must store extractor metadata returned from the `extract` call' do
     extractor = mock('extractor')
     extractor.expects(:match_file).with(GOLANG_SAMPLE).returns(true)
-    extractor.expects(:extract).with(GOLANG_SAMPLE).returns(:a => 1)
+    extractor.expects(:extract).with(GOLANG_SAMPLE, File.read(GOLANG_SAMPLE)).returns(:a => 1)
     extractor.expects(:name).returns('Foo')
     EXTRACTORS.stubs(:each).yields(extractor)
 

--- a/test/unit/langs/golang_test.rb
+++ b/test/unit/langs/golang_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../../test_helper', __FILE__)
 describe Starscope::Lang::Go do
   before do
     @db = {}
-    Starscope::Lang::Go.extract(GOLANG_SAMPLE) do |tbl, name, args|
+    Starscope::Lang::Go.extract(GOLANG_SAMPLE, File.read(GOLANG_SAMPLE)) do |tbl, name, args|
       @db[tbl] ||= []
       @db[tbl] << Starscope::DB.normalize_record(GOLANG_SAMPLE, name, args)
     end

--- a/test/unit/langs/ruby_test.rb
+++ b/test/unit/langs/ruby_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../../test_helper', __FILE__)
 describe Starscope::Lang::Ruby do
   before do
     @db = {}
-    Starscope::Lang::Ruby.extract(RUBY_SAMPLE) do |tbl, name, args|
+    Starscope::Lang::Ruby.extract(RUBY_SAMPLE, File.read(RUBY_SAMPLE)) do |tbl, name, args|
       @db[tbl] ||= []
       @db[tbl] << Starscope::DB.normalize_record(RUBY_SAMPLE, name, args)
     end


### PR DESCRIPTION
It now takes the path and the contents directly, rather than just the file-name.
This is in preparation for handling nested fragments (like ruby-in-ERB).