### PR TITLE
Implement nested language blocks

### DIFF
--- a/lib/starscope/fragment_extractor.rb
+++ b/lib/starscope/fragment_extractor.rb
@@ -1,0 +1,22 @@
+class Starscope::FragmentExtractor
+  def initialize(lang, frags)
+    @child = Starscope::Lang.const_get(lang)
+    @frags = frags
+  end
+
+  def extract(path, text)
+    text = @frags.map { |f| f.delete(:frag).strip }.join("\n")
+
+    extractor_metadata = @child.extract(path, text) do |tbl, name, args|
+      args.merge!(@frags[args[:line_no] - 1]) if args[:line_no]
+      yield tbl, name, args
+    end
+
+    # TODO: translate metadata?
+    extractor_metadata
+  end
+
+  def name
+    @child.name
+  end
+end

--- a/test/fixtures/db_old_subextractor.json
+++ b/test/fixtures/db_old_subextractor.json
@@ -1,0 +1,17 @@
+5
+{
+    ":paths": [],
+    ":excludes": [],
+    ":langs": {
+        ":Go": 1234,
+        ":Ruby": 0
+    },
+    ":files": {
+        "test/fixtures/sample_golang.go": {
+            ":last_updated": 10000000000,
+            ":lang": ":Go",
+            ":sublangs": [":Ruby"]
+        }
+    }
+}
+{}

--- a/test/unit/db_test.rb
+++ b/test/unit/db_test.rb
@@ -74,6 +74,22 @@ describe Starscope::DB do
     @db.records(:calls).wont_be_empty
   end
 
+  it 'must update unchanged existing files with old sublang extractor versions' do
+    @db.load("#{FIXTURES}/db_old_subextractor.json")
+
+    cur_mtime = @db.metadata(:files)[GOLANG_SAMPLE][:last_updated]
+    File.expects(:mtime).twice.returns(cur_mtime)
+    @db.update
+
+    file = @db.metadata(:files)[GOLANG_SAMPLE]
+    file[:last_updated].must_equal cur_mtime
+    file[:lang].must_equal :Go
+    file[:sublangs].must_be_empty
+    file[:lines].wont_be_empty
+    @db.records(:defs).wont_be_empty
+    @db.records(:calls).wont_be_empty
+  end
+
   it 'must not update file with up-to-date time and extractor' do
     @db.load("#{FIXTURES}/db_up_to_date.json")
     @db.update

--- a/test/unit/fragment_extractor_test.rb
+++ b/test/unit/fragment_extractor_test.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+describe Starscope::FragmentExtractor do
+  module ::Starscope::Lang::Dummy; end
+
+  before do
+    @extractor = Starscope::FragmentExtractor.new(:Dummy, [
+      { :frag => "def foo; end\n", :line_no => 12 },
+      { :frag => "def bar\n", :line_no => 15 },
+      { :frag => "end\n", :line_no => 29 }
+    ])
+    @reconstructed = "def foo; end\ndef bar\nend"
+  end
+
+  it 'must pass reconstructed text to the child' do
+    ::Starscope::Lang::Dummy.expects(:extract).with(:foo, @reconstructed)
+    @extractor.extract(:foo, '---')
+  end
+
+  it 'must pass along extractor metadata from the child' do
+    ::Starscope::Lang::Dummy.expects(:extract).returns :a => 1, :b => 3
+    @extractor.extract(:foo, '---').must_equal :a => 1, :b => 3
+  end
+
+  it 'must pass along the name from the child' do
+    @extractor.name.must_equal ::Starscope::Lang::Dummy.name
+  end
+
+  it 'must override-merge yielded args based on line number' do
+    ::Starscope::Lang::Dummy.expects(:extract).yields(:foo, :bar, :line_no => 2, :foo => :bar)
+
+    @extractor.extract(:foo, '---') do |tbl, name, args|
+      tbl.must_equal :foo
+      name.must_equal :bar
+      args.must_equal :line_no => 15, :foo => :bar
+    end
+  end
+end


### PR DESCRIPTION
Add a magic `FragmentExtractor` which behaves like a language but wraps a real
language to parse fragments nested in another file.

Adjust `DB#extract_file` to use it.

Add a specially defined `FRAGMENT` table for extractors to yield when generating
fragments.

Fixes #61 