### PR TITLE
Handle the existence of removed langs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ New Features:
  * Implement support for files with multiple nested languages (#61).
  * Implement support for extracting ruby inside ERB files (#120).
 
+Bug Fixes:
+ * Correctly handle the removal of language extractors (#122).
+
 Misc:
  * Preliminary use of Rubocop for more consistent code style.
  * Document the fact that `!` can't be used at the beginning of table names.

--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -307,7 +307,9 @@ class Starscope::DB
   end
 
   def language_out_of_date(lang)
-    lang && (@meta[:langs][lang] || 0) < LANGS[lang]
+    return false unless lang
+    return true unless LANGS[lang]
+    (@meta[:langs][lang] || 0) < LANGS[lang]
   end
 
   def self.normalize_record(file, name, args)

--- a/test/fixtures/db_missing_language.json
+++ b/test/fixtures/db_missing_language.json
@@ -1,0 +1,15 @@
+5
+{
+    ":paths": [],
+    ":excludes": [],
+    ":langs": {
+        ":NoSuchLanguage": 0
+    },
+    ":files": {
+        "test/fixtures/sample_golang.go": {
+            ":last_updated": 10000000000,
+            ":lang": ":NoSuchLanguage"
+        }
+    }
+}
+{}

--- a/test/unit/db_test.rb
+++ b/test/unit/db_test.rb
@@ -90,6 +90,21 @@ describe Starscope::DB do
     @db.records(:calls).wont_be_empty
   end
 
+  it 'must update unchanged existing files when the extractor has been removed' do
+    @db.load("#{FIXTURES}/db_missing_language.json")
+
+    cur_mtime = @db.metadata(:files)[GOLANG_SAMPLE][:last_updated]
+    File.expects(:mtime).twice.returns(cur_mtime)
+    @db.update
+
+    file = @db.metadata(:files)[GOLANG_SAMPLE]
+    file[:last_updated].must_equal cur_mtime
+    file[:lang].must_equal :Go
+    file[:lines].wont_be_empty
+    @db.records(:defs).wont_be_empty
+    @db.records(:calls).wont_be_empty
+  end
+
   it 'must not update file with up-to-date time and extractor' do
     @db.load("#{FIXTURES}/db_up_to_date.json")
     @db.update


### PR DESCRIPTION
(e.g. coffeescript) in loaded databases