### PR TITLE
Drop 1.8

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,9 +34,6 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
-Style/HashSyntax:
-  EnforcedStyle: hash_rockets
-
 Style/Next:
   Exclude:
     - 'test/fixtures/sample_ruby.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 
 rvm:
-    - 1.8.7
     - 1.9.3
     - 2.0
     - 2.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     starscope (1.4.2)
-      backports (~> 3.6)
       oj (~> 2.9)
       parser (~> 2.2.2)
       ruby-progressbar (~> 1.5)
@@ -11,14 +10,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.1.0)
-    backports (3.6.6)
     coderay (1.1.0)
     metaclass (0.0.4)
     method_source (0.8.2)
     minitest (5.8.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    oj (2.12.13)
+    oj (2.12.14)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     pry (0.10.1)

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ Rake::TestTask.new do |t|
 end
 
 desc 'Run tests'
-task :default => :test
+task default: :test

--- a/bin/starscope
+++ b/bin/starscope
@@ -9,12 +9,12 @@ require 'starscope'
 
 DEFAULT_DB = '.starscope.db'
 
-options = { :read => true,
-            :write => true,
-            :update => true,
-            :output => :normal,
-            :export => [],
-            :db => DEFAULT_DB
+options = { read: true,
+            write: true,
+            update: true,
+            output: :normal,
+            export: [],
+            db: DEFAULT_DB
 }
 
 # Options Parsing

--- a/bin/starscope
+++ b/bin/starscope
@@ -100,7 +100,7 @@ end.parse!
 def print_summary(db)
   tables = db.tables
   puts 'No tables' if tables.empty?
-  tables.sort { |a, b| a.to_s <=> b.to_s }.each do |table|
+  tables.sort.each do |table|
     printf("%-9s %6d records\n", table, db.records(table).length)
   end
 end

--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -1,4 +1,3 @@
-require 'backports'
 require 'date'
 require 'oj'
 require 'set'

--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -32,8 +32,8 @@ class Starscope::DB
 
   def initialize(output)
     @output = output
-    @meta = { :paths => [], :files => {}, :excludes => [],
-              :langs => LANGS, :version => Starscope::VERSION }
+    @meta = { paths: [], files: {}, excludes: [],
+              langs: LANGS, version: Starscope::VERSION }
     @tables = {}
   end
 
@@ -237,7 +237,7 @@ class Starscope::DB
   end
 
   def parse_file(file)
-    @meta[:files][file] = { :last_updated => File.mtime(file).to_i }
+    @meta[:files][file] = { last_updated: File.mtime(file).to_i }
 
     EXTRACTORS.each do |extractor|
       begin

--- a/lib/starscope/exportable.rb
+++ b/lib/starscope/exportable.rb
@@ -228,8 +228,8 @@ END
   def valid_index?(line, index, key)
     # index is valid if the key exists at it, and the prev/next chars are not word characters
     ((line[index, key.length] == key) &&
-     (index == 0 || line[index - 1] !~ /\w/) &&
-     (index + key.length == line.length || line[index + key.length] !~ /\w/))
+     (index == 0 || line[index - 1] !~ /[[:word:]]/) &&
+     (index + key.length == line.length || line[index + key.length] !~ /[[:word:]]/))
   end
 
   def cscope_plaintext(line, start, stop)

--- a/lib/starscope/langs/erb.rb
+++ b/lib/starscope/langs/erb.rb
@@ -18,18 +18,18 @@ module Starscope::Lang
         if multiline
           term = line.index(ERB_END)
           if term
-            yield FRAGMENT, :Ruby, :frag => line[0...term], :line_no => line_no
+            yield FRAGMENT, :Ruby, frag: line[0...term], line_no: line_no
             line = line[term + 1..-1]
             multiline = false
           else
-            yield FRAGMENT, :Ruby, :frag => line, :line_no => line_no
+            yield FRAGMENT, :Ruby, frag: line, line_no: line_no
           end
         end
 
         next if multiline
 
         line.scan(/#{ERB_START}(.*?)#{ERB_END}/) do |match|
-          yield FRAGMENT, :Ruby, :frag => match[0], :line_no => line_no
+          yield FRAGMENT, :Ruby, frag: match[0], line_no: line_no
         end
 
         line.gsub!(/<%.*?%>/, '')
@@ -37,7 +37,7 @@ module Starscope::Lang
         match = /#{ERB_START}(.*)$/.match(line)
         next unless match
 
-        yield FRAGMENT, :Ruby, :frag => match[1], :line_no => line_no
+        yield FRAGMENT, :Ruby, frag: match[1], line_no: line_no
         multiline = true
       end
     end

--- a/lib/starscope/langs/go.rb
+++ b/lib/starscope/langs/go.rb
@@ -41,10 +41,10 @@ module Starscope::Lang
         if stack[-1] != :import && !line.start_with?('import')
           # strip string literals like "foo" unless they're part of an import
           pos = 0
-          while (match = STRING_LITERAL.match(line[pos..-1]))
+          while (match = STRING_LITERAL.match(line, pos))
             eos = find_end_of_string(line, match.begin(0))
             line = line[0..match.begin(0)] + line[eos..-1]
-            pos += match.begin(0) + 2
+            pos = match.begin(0) + 2
           end
         end
 
@@ -192,9 +192,9 @@ module Starscope::Lang
       (start + 1...line.length).each do |i|
         if escape
           escape = false
-        elsif line[i].chr == '\\'
+        elsif line[i] == '\\'
           escape = true
-        elsif line[i].chr == '"'
+        elsif line[i] == '"'
           return i
         end
       end

--- a/lib/starscope/langs/ruby.rb
+++ b/lib/starscope/langs/ruby.rb
@@ -40,45 +40,45 @@ module Starscope::Lang
       case node.type
       when :send
         name = scoped_name(node, scope)
-        yield :calls, name, :line_no => loc.line, :col => loc.column
+        yield :calls, name, line_no: loc.line, col: loc.column
 
         if name.last.to_s =~ /\w+=$/
           name[-1] = name.last.to_s.chop.to_sym
-          yield :assigns, name, :line_no => loc.line, :col => loc.column
+          yield :assigns, name, line_no: loc.line, col: loc.column
         elsif node.children[0].nil? && node.children[1] == :require && node.children[2].type == :str
           yield :requires, node.children[2].children[0].split('/'),
-            :line_no => loc.line, :col => loc.column
+            line_no: loc.line, col: loc.column
         end
 
       when :def
         yield :defs, scope + [node.children[0]],
-          :line_no => loc.line, :type => :func, :col => loc.name.column
-        yield :end, :end, :line_no => loc.end.line, :type => :func, :col => loc.end.column
+          line_no: loc.line, type: :func, col: loc.name.column
+        yield :end, :end, line_no: loc.end.line, type: :func, col: loc.end.column
 
       when :defs
         yield :defs, scope + [node.children[1]],
-          :line_no => loc.line, :type => :func, :col => loc.name.column
-        yield :end, :end, :line_no => loc.end.line, :type => :func, :col => loc.end.column
+          line_no: loc.line, type: :func, col: loc.name.column
+        yield :end, :end, line_no: loc.end.line, type: :func, col: loc.end.column
 
       when :module, :class
         yield :defs, scope + scoped_name(node.children[0], scope),
-          :line_no => loc.line, :type => node.type, :col => loc.name.column
-        yield :end, :end, :line_no => loc.end.line, :type => node.type, :col => loc.end.column
+          line_no: loc.line, type: node.type, col: loc.name.column
+        yield :end, :end, line_no: loc.end.line, type: node.type, col: loc.end.column
 
       when :casgn
         name = scoped_name(node, scope)
-        yield :assigns, name, :line_no => loc.line, :col => loc.name.column
-        yield :defs, name, :line_no => loc.line, :col => loc.name.column
+        yield :assigns, name, line_no: loc.line, col: loc.name.column
+        yield :defs, name, line_no: loc.line, col: loc.name.column
 
       when :lvasgn, :ivasgn, :cvasgn, :gvasgn
-        yield :assigns, scope + [node.children[0]], :line_no => loc.line, :col => loc.name.column
+        yield :assigns, scope + [node.children[0]], line_no: loc.line, col: loc.name.column
 
       when :const
         name = scoped_name(node, scope)
-        yield :reads, name, :line_no => loc.line, :col => loc.name.column
+        yield :reads, name, line_no: loc.line, col: loc.name.column
 
       when :lvar, :ivar, :cvar, :gvar
-        yield :reads, scope + [node.children[0]], :line_no => loc.line, :col => loc.name.column
+        yield :reads, scope + [node.children[0]], line_no: loc.line, col: loc.name.column
 
       when :sym
         # handle `:foo` vs `foo: 1`
@@ -87,7 +87,7 @@ module Starscope::Lang
               else
                 loc.expression.column
               end
-        yield :sym, [node.children[0]], :line_no => loc.line, :col => col
+        yield :sym, [node.children[0]], line_no: loc.line, col: col
       end
     end
 

--- a/lib/starscope/langs/ruby.rb
+++ b/lib/starscope/langs/ruby.rb
@@ -42,7 +42,7 @@ module Starscope::Lang
         name = scoped_name(node, scope)
         yield :calls, name, line_no: loc.line, col: loc.column
 
-        if name.last.to_s =~ /\w+=$/
+        if name.last =~ /\w+=$/
           name[-1] = name.last.to_s.chop.to_sym
           yield :assigns, name, line_no: loc.line, col: loc.column
         elsif node.children[0].nil? && node.children[1] == :require && node.children[2].type == :str

--- a/lib/starscope/output.rb
+++ b/lib/starscope/output.rb
@@ -11,9 +11,9 @@ class Starscope::Output
 
   def new_pbar(title, num_items)
     return if @level == :quiet
-    @pbar = ProgressBar.create(:title => title, :total => num_items,
-                               :format => PBAR_FORMAT, :length => 80,
-                               :out => @out)
+    @pbar = ProgressBar.create(title: title, total: num_items,
+                               format: PBAR_FORMAT, length: 80,
+                               out: @out)
   end
 
   def inc_pbar

--- a/starscope.gemspec
+++ b/starscope.gemspec
@@ -17,12 +17,11 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.test_files    = `git ls-files -- test/*`.split("\n")
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '>= 1.8.7'
+  gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'oj', '~> 2.9'
   gem.add_dependency 'parser', '~> 2.2.2'
   gem.add_dependency 'ruby-progressbar', '~> 1.5'
-  gem.add_dependency 'backports', '~> 3.6'
   gem.add_development_dependency 'bundler', '~> 1.5'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'pry'

--- a/test/fixtures/sample_ruby.rb
+++ b/test/fixtures/sample_ruby.rb
@@ -26,7 +26,7 @@ class Starscope::DB
         if format == DB_FORMAT
           @paths  = Oj.load(stream.gets)
           @files  = Oj.load(stream.gets)
-          @tables = Oj.load(stream.gets, :symbol_keys => true)
+          @tables = Oj.load(stream.gets, symbol_keys: true)
         elsif format <= 2
           # Old format (pre-json), so read the directories segment then rebuild
           len = stream.gets.to_i
@@ -59,7 +59,7 @@ class Starscope::DB
     files = paths.map { |p| self.class.files_from_path(p) }.flatten
     return if files.empty?
     if @progress
-      pbar = ProgressBar.create(:title => 'Building', :total => files.length, :format => PBAR_FORMAT, :length => 80)
+      pbar = ProgressBar.create(title: 'Building', total: files.length, format: PBAR_FORMAT, length: 80)
     end
     files.each do |f|
       add_file(f)
@@ -70,7 +70,7 @@ class Starscope::DB
   def update
     new_files = (@paths.map { |p| self.class.files_from_path(p) }.flatten) - @files.keys
     if @progress
-      pbar = ProgressBar.create(:title => 'Updating', :total => new_files.length + @files.length, :format => PBAR_FORMAT, :length => 80)
+      pbar = ProgressBar.create(title: 'Updating', total: new_files.length + @files.length, format: PBAR_FORMAT, length: 80)
     end
     changed = @files.keys.map do |f|
       changed = update_file(f)
@@ -114,7 +114,7 @@ class Starscope::DB
           if entry[:line_no]
             tmpdb[entry[:file]] ||= {}
             tmpdb[entry[:file]][entry[:line_no]] ||= []
-            tmpdb[entry[:file]][entry[:line_no]] << { :tbl => tbl, :key => key, :entry => entry }
+            tmpdb[entry[:file]][entry[:line_no]] << { tbl: tbl, key: key, entry: entry }
           end
         end
       end

--- a/test/functional/starscope_test.rb
+++ b/test/functional/starscope_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require_relative '../test_helper'
 
 describe 'starscope executable script' do
   BASE = 'bundle exec bin/starscope --quiet'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'mocha/mini_test'
-require File.expand_path('../../lib/starscope.rb', __FILE__)
+require_relative '../lib/starscope'
 
 FIXTURES = 'test/fixtures'
 

--- a/test/unit/db_test.rb
+++ b/test/unit/db_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require_relative '../test_helper'
 require 'tempfile'
 
 describe Starscope::DB do

--- a/test/unit/db_test.rb
+++ b/test/unit/db_test.rb
@@ -161,7 +161,7 @@ describe Starscope::DB do
   it 'must store extractor metadata returned from the `extract` call' do
     extractor = mock('extractor')
     extractor.expects(:match_file).with(GOLANG_SAMPLE).returns(true)
-    extractor.expects(:extract).with(GOLANG_SAMPLE, File.read(GOLANG_SAMPLE)).returns(:a => 1)
+    extractor.expects(:extract).with(GOLANG_SAMPLE, File.read(GOLANG_SAMPLE)).returns(a: 1)
     extractor.expects(:name).returns('Foo')
     EXTRACTORS.stubs(:each).yields(extractor)
 

--- a/test/unit/exportable_test.rb
+++ b/test/unit/exportable_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require_relative '../test_helper'
 
 describe Starscope::Exportable do
   before do

--- a/test/unit/exportable_test.rb
+++ b/test/unit/exportable_test.rb
@@ -10,14 +10,14 @@ describe Starscope::Exportable do
   it 'must export to ctags' do
     @db.export_to(:ctags, @buf)
     @buf.rewind
-    lines = @buf.lines.to_a
+    lines = @buf.each_line.to_a
     lines.must_include "NoTableError\t#{FIXTURES}/sample_ruby.rb\t/^  class NoTableError < StandardError; end$/;\"\tkind:c\tlanguage:Ruby\n"
   end
 
   it 'must export to cscope' do
     @db.export_to(:cscope, @buf)
     @buf.rewind
-    lines = @buf.lines.to_a
+    lines = @buf.each_line.to_a
 
     lines.must_include "\t@#{FIXTURES}/sample_golang.go\n"
     lines.must_include "\tgSunday\n"

--- a/test/unit/fragment_extractor_test.rb
+++ b/test/unit/fragment_extractor_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require_relative '../test_helper'
 
 describe Starscope::FragmentExtractor do
   module ::Starscope::Lang::Dummy; end

--- a/test/unit/fragment_extractor_test.rb
+++ b/test/unit/fragment_extractor_test.rb
@@ -5,9 +5,9 @@ describe Starscope::FragmentExtractor do
 
   before do
     @extractor = Starscope::FragmentExtractor.new(:Dummy, [
-      { :frag => "def foo; end\n", :line_no => 12 },
-      { :frag => "def bar\n", :line_no => 15 },
-      { :frag => "end\n", :line_no => 29 }
+      { frag: "def foo; end\n", line_no: 12 },
+      { frag: "def bar\n", line_no: 15 },
+      { frag: "end\n", line_no: 29 }
     ])
     @reconstructed = "def foo; end\ndef bar\nend"
   end
@@ -18,8 +18,8 @@ describe Starscope::FragmentExtractor do
   end
 
   it 'must pass along extractor metadata from the child' do
-    ::Starscope::Lang::Dummy.expects(:extract).returns :a => 1, :b => 3
-    @extractor.extract(:foo, '---').must_equal :a => 1, :b => 3
+    ::Starscope::Lang::Dummy.expects(:extract).returns a: 1, b: 3
+    @extractor.extract(:foo, '---').must_equal a: 1, b: 3
   end
 
   it 'must pass along the name from the child' do
@@ -27,12 +27,12 @@ describe Starscope::FragmentExtractor do
   end
 
   it 'must override-merge yielded args based on line number' do
-    ::Starscope::Lang::Dummy.expects(:extract).yields(:foo, :bar, :line_no => 2, :foo => :bar)
+    ::Starscope::Lang::Dummy.expects(:extract).yields(:foo, :bar, line_no: 2, foo: :bar)
 
     @extractor.extract(:foo, '---') do |tbl, name, args|
       tbl.must_equal :foo
       name.must_equal :bar
-      args.must_equal :line_no => 15, :foo => :bar
+      args.must_equal line_no: 15, foo: :bar
     end
   end
 end

--- a/test/unit/langs/erb_test.rb
+++ b/test/unit/langs/erb_test.rb
@@ -20,17 +20,17 @@ describe Starscope::Lang::ERB do
   end
 
   it 'must identify all fragments' do
-    @frags.must_equal [{ :frag => ' if foo ', :line_no => 1 },
-                       { :frag => ' elsif bar ', :line_no => 3 },
-                       { :frag => ' end ', :line_no => 5 },
-                       { :frag => ' case x', :line_no => 8 },
-                       { :frag => 'when :bar ', :line_no => 9 },
-                       { :frag => ' magic ', :line_no => 9 },
-                       { :frag => ' when :baz', :line_no => 9 },
-                       { :frag => 'when :foo ', :line_no => 10 },
-                       { :frag => ' end ', :line_no => 12 },
-                       { :frag => ' foo ', :line_no => 14 },
-                       { :frag => ' bar ', :line_no => 14 },
-                       { :frag => ' baz ', :line_no => 14 }]
+    @frags.must_equal [{ frag: ' if foo ', line_no: 1 },
+                       { frag: ' elsif bar ', line_no: 3 },
+                       { frag: ' end ', line_no: 5 },
+                       { frag: ' case x', line_no: 8 },
+                       { frag: 'when :bar ', line_no: 9 },
+                       { frag: ' magic ', line_no: 9 },
+                       { frag: ' when :baz', line_no: 9 },
+                       { frag: 'when :foo ', line_no: 10 },
+                       { frag: ' end ', line_no: 12 },
+                       { frag: ' foo ', line_no: 14 },
+                       { frag: ' bar ', line_no: 14 },
+                       { frag: ' baz ', line_no: 14 }]
   end
 end

--- a/test/unit/langs/erb_test.rb
+++ b/test/unit/langs/erb_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../test_helper', __FILE__)
+require_relative '../../test_helper'
 
 describe Starscope::Lang::ERB do
   before do

--- a/test/unit/langs/golang_test.rb
+++ b/test/unit/langs/golang_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../test_helper', __FILE__)
+require_relative '../../test_helper'
 
 describe Starscope::Lang::Go do
   before do

--- a/test/unit/langs/ruby_test.rb
+++ b/test/unit/langs/ruby_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../../test_helper', __FILE__)
+require_relative '../../test_helper'
 
 describe Starscope::Lang::Ruby do
   before do

--- a/test/unit/output_test.rb
+++ b/test/unit/output_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require_relative '../test_helper'
 
 describe Starscope::Output do
   it 'must be quiet' do

--- a/test/unit/queryable_test.rb
+++ b/test/unit/queryable_test.rb
@@ -2,22 +2,22 @@ require File.expand_path('../../test_helper', __FILE__)
 
 describe Starscope::Queryable do
   SAMPLE_RECORDS = [
-    { :name => [:"[abc"], :foo => 'baz' },
-    { :name => [:"not a match"], :foo => 'bar', :x => 'y' },
-    { :name => [:a, :b, :c, :d], :file => :somefile }
+    { name: [:"[abc"], foo: 'baz' },
+    { name: [:"not a match"], foo: 'bar', x: 'y' },
+    { name: [:a, :b, :c, :d], file: :somefile }
   ]
 
   class MockQuerable
     include Starscope::Queryable
     def initialize
       @tables = {
-        :mytable => SAMPLE_RECORDS,
-        :empty_table => []
+        mytable: SAMPLE_RECORDS,
+        empty_table: []
       }
       @meta = {
-        :files => {
-          :somefile => {
-            :lang => :ruby
+        files: {
+          somefile: {
+            lang: :ruby
           }
         }
       }
@@ -47,15 +47,15 @@ describe Starscope::Queryable do
   end
 
   it 'must handle simple filters' do
-    @mock.query(:mytable, '.*', :foo => 'bar').must_equal [SAMPLE_RECORDS[1]]
+    @mock.query(:mytable, '.*', foo: 'bar').must_equal [SAMPLE_RECORDS[1]]
   end
 
   it 'must handle multiple filters' do
-    @mock.query(:mytable, '.*', :foo => 'bar', :x => 'y').must_equal [SAMPLE_RECORDS[1]]
-    @mock.query(:mytable, '.*', :foo => 'bar', :x => 'nope').must_be_empty
+    @mock.query(:mytable, '.*', foo: 'bar', x: 'y').must_equal [SAMPLE_RECORDS[1]]
+    @mock.query(:mytable, '.*', foo: 'bar', x: 'nope').must_be_empty
   end
 
   it 'must handle filters on file properties' do
-    @mock.query(:mytable, '.*', :lang => 'ruby').must_equal [SAMPLE_RECORDS[2]]
+    @mock.query(:mytable, '.*', lang: 'ruby').must_equal [SAMPLE_RECORDS[2]]
   end
 end

--- a/test/unit/queryable_test.rb
+++ b/test/unit/queryable_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require_relative '../test_helper'
 
 describe Starscope::Queryable do
   SAMPLE_RECORDS = [


### PR DESCRIPTION
Fixes #67. Required for javascript support, since `execjs` needs 1.9.3 anyways. Over a year since 1.8 was EOL.