### PR TITLE
Ensure that `cscope_plaintext` never returns ''

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ v1.5.0 (trunk)
 New Features:
  * Javascript support, including basic ES6/ES7 and JSX (via Babel).
 
+Bug Fixes:
+ * Fixed a really weird corruption in certain rare cscope export cases (#129).
+
 Misc:
  * Drop support for ruby 1.8.7, it was getting annoying and is long unsupported.
 

--- a/lib/starscope/exportable.rb
+++ b/lib/starscope/exportable.rb
@@ -236,7 +236,8 @@ END
     ret = line.slice(start, stop - start)
     ret.lstrip! if start == 0
     ret.rstrip! if stop == line.length
-    ret.gsub(/\s+/, ' ')
+    ret.gsub!(/\s+/, ' ')
+    ret.empty? ? ' ' : ret
   rescue ArgumentError
     # invalid utf-8 byte sequence in the line, oh well
     line


### PR DESCRIPTION
If it does, we'll accidentally create a cscope file with two consecutive
newlines in the middle of a single 'real' source line. This is effectively a
corrupt file that only ever shows up if you search for a symbol on that line,
because cscope's parsing logic is so weird.

I had to read cscope's source to track this one down. The annoying case was in a
particular javascript file, but this probably solves a whole raft of heisenbugs
in ruby and go as well.