### PR TITLE
Don't use `private` keyword in a module

### DIFF
--- a/lib/starscope/langs/ruby.rb
+++ b/lib/starscope/langs/ruby.rb
@@ -18,8 +18,6 @@ module Starscope::Lang
       extract_tree(ast, [], &block) unless ast.nil?
     end
 
-    private
-
     def self.extract_tree(tree, scope, &block)
       extract_node(tree, scope, &block)
 


### PR DESCRIPTION
It does nothing to module meta-methods and is misleading.