### PR TITLE
Fix double-parsing of JS static class methods

### DIFF
--- a/test/fixtures/sample_javascript.js
+++ b/test/fixtures/sample_javascript.js
@@ -28,15 +28,11 @@ function foo() {
 StatusBarIOS.setStyle(1);
 Router.routes = routes;
 
-var NavigatorRouteMapper = {
-  Title({route}) {
-    return (
-      <View style={styles.navigatorBar}>
-        <Text style={{color: Branding.white, fontFamily: Branding.fontBold, fontSize: 16}}>{route.title}</Text>
-      </View>
-    );
-  },
+class MyStat {
+  static myStatFunc() {}
+}
 
+var NavigatorRouteMapper = {
   LeftButton({route}, navigator, index) {
     if (!index) { return null; } // Nothing below in stack.
 
@@ -62,8 +58,6 @@ class Navigation extends Component {
 
   _tabItem(routeName: string, params: Object, badgeCount?: number) : PropTypes.element {
     var route = routes[routeName];
-    var title = route.title;
-    var icon = route.icon;
 
     var onTabPress = () => {
       if (this.state.selectedTab === routeName) {
@@ -79,8 +73,6 @@ class Navigation extends Component {
 
     return (
       <TabBarIOS.Item
-        icon={icon}
-        title={title}
         badge={badgeCount}
         selected={this.state.selectedTab === routeName}
         onPress={onTabPress}

--- a/test/unit/langs/javascript_test.rb
+++ b/test/unit/langs/javascript_test.rb
@@ -26,7 +26,6 @@ describe Starscope::Lang::Javascript do
     defs.must_include :StyleSheet
     defs.must_include :styles
     defs.must_include :NavigatorRouteMapper
-    defs.must_include :Title
     defs.must_include :LeftButton
     defs.must_include :RightButton
     defs.must_include :_tabItem
@@ -34,6 +33,8 @@ describe Starscope::Lang::Javascript do
     defs.must_include :setRef
     defs.must_include :route
     defs.must_include :foo
+    defs.must_include :MyStat
+    defs.must_include :myStatFunc
 
     defs.wont_include :setStyle
     defs.wont_include :setState
@@ -41,9 +42,13 @@ describe Starscope::Lang::Javascript do
     defs.wont_include :navigator
   end
 
+  it 'must only tag static classes once' do
+    @db[:defs].count { |x| x[:name][-1] == :MyStat }.must_equal 1
+  end
+
   it 'must identify endings' do
     @db.keys.must_include :end
-    @db[:end].count.must_equal 9
+    @db[:end].count.must_equal 10
   end
 
   it 'must identify function calls' do


### PR DESCRIPTION
Move to 3 passes, which kind of sucks (but isn't the perf bottleneck anyways,
that's still babel). Split them out into readable functions. Add a test for this
problem, and trim down some unnecessary sample javascript.