### PR TITLE
JS requires

### DIFF
--- a/lib/starscope/langs/javascript.rb
+++ b/lib/starscope/langs/javascript.rb
@@ -57,9 +57,14 @@ module Starscope::Lang
           line = find_line(node.range.from, map, lines, name)
           next unless line
 
-          yield :calls, name, line_no: line
           found[name] ||= Set.new
           found[name].add(line)
+
+          if name == 'require'
+            yield :requires, node.arguments.value[0].value[1...-1], line_no: line
+          else
+            yield :calls, name, line_no: line
+          end
         end
       end
 
@@ -72,6 +77,15 @@ module Starscope::Lang
 
         line = find_line(node.range.from, map, lines, node.name)
         next unless line
+
+        if node.value.is_a?(RKelly::Nodes::AssignExprNode) &&
+           node.value.value.is_a?(RKelly::Nodes::FunctionCallNode) &&
+           node.value.value.value.is_a?(RKelly::Nodes::ResolveNode) &&
+           node.value.value.value.value == 'require'
+          found[node.name] ||= Set.new
+          found[node.name].add(line)
+          next
+        end
 
         next if found[node.name] && found[node.name].include?(line)
         yield :defs, node.name, line_no: line

--- a/test/fixtures/sample_javascript.js
+++ b/test/fixtures/sample_javascript.js
@@ -2,6 +2,8 @@
 
 import React from 'react-native';
 
+let madness = require('foo-bar');
+
 var {
   Component,
   StyleSheet,

--- a/test/functional/starscope_test.rb
+++ b/test/functional/starscope_test.rb
@@ -22,7 +22,9 @@ describe 'starscope executable script' do
   it 'must produce a valid database dump' do
     lines = `#{EXTRACT} -d requires`.lines.to_a
     lines[1].split.first.must_equal 'date'
-    lines[2].split.first.must_equal 'zlib'
+    lines[2].split.first.must_equal 'foo-bar'
+    lines[3].split.first.must_equal 'react-native'
+    lines[4].split.first.must_equal 'zlib'
   end
 
   it 'must correctly query the database' do

--- a/test/unit/langs/javascript_test.rb
+++ b/test/unit/langs/javascript_test.rb
@@ -40,6 +40,7 @@ describe Starscope::Lang::Javascript do
     defs.wont_include :setState
     defs.wont_include :fontFamily
     defs.wont_include :navigator
+    defs.wont_include :madness
   end
 
   it 'must only tag static classes once' do
@@ -64,5 +65,12 @@ describe Starscope::Lang::Javascript do
 
     calls[:pop].count.must_equal 1
     calls[:_tabItem].count.must_equal 3
+  end
+
+  it 'must identify module requires' do
+    @db.keys.must_include :requires
+    requires = @db[:requires].group_by { |x| x[:name][-1] }
+
+    requires.keys.must_include :'foo-bar'
   end
 end

--- a/test/unit/langs/javascript_test.rb
+++ b/test/unit/langs/javascript_test.rb
@@ -41,6 +41,7 @@ describe Starscope::Lang::Javascript do
     defs.wont_include :fontFamily
     defs.wont_include :navigator
     defs.wont_include :madness
+    defs.wont_include :React
   end
 
   it 'must only tag static classes once' do
@@ -72,5 +73,6 @@ describe Starscope::Lang::Javascript do
     requires = @db[:requires].group_by { |x| x[:name][-1] }
 
     requires.keys.must_include :'foo-bar'
+    requires.keys.must_include :'react-native'
   end
 end


### PR DESCRIPTION
Handle `require` and `import` in javascript as actual module requires rather than as regular function calls or variable definitions.