### PR TITLE
javascript: correctly handle braceless methods

### DIFF
--- a/lib/starscope/langs/javascript.rb
+++ b/lib/starscope/langs/javascript.rb
@@ -49,7 +49,11 @@ module Starscope::Lang
           next if type == :class
 
           mapping = map.bsearch(SourceMap::Offset.new(node.range.to.line, node.range.to.char))
-          yield :end, :'}', line_no: mapping.original.line, type: type
+          if lines[mapping.original.line - 1].include? '}'
+            yield :end, '}', line_no: mapping.original.line, type: type
+          else
+            yield :end, '', line_no: mapping.original.line, type: type, col: mapping.original.column
+          end
         when RKelly::Nodes::FunctionCallNode
           name = node_name(node.value)
           next unless name

--- a/test/fixtures/sample_javascript.js
+++ b/test/fixtures/sample_javascript.js
@@ -17,6 +17,7 @@ var styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  bracelessMethod: () => 42,
 });
 
 var func1 = () => {

--- a/test/unit/langs/javascript_test.rb
+++ b/test/unit/langs/javascript_test.rb
@@ -35,6 +35,7 @@ describe Starscope::Lang::Javascript do
     defs.must_include :foo
     defs.must_include :MyStat
     defs.must_include :myStatFunc
+    defs.must_include :bracelessMethod
 
     defs.wont_include :setStyle
     defs.wont_include :setState
@@ -50,7 +51,12 @@ describe Starscope::Lang::Javascript do
 
   it 'must identify endings' do
     @db.keys.must_include :end
-    @db[:end].count.must_equal 11
+    @db[:end].count.must_equal 12
+
+    # bracelessMethod doesn't have a taggable end token so
+    # we have to do a little dancing with an empty name and a precise column
+    @db[:end][0][:name].must_equal [:'']
+    @db[:end][0][:col].must_equal 27
   end
 
   it 'must identify function calls' do


### PR DESCRIPTION
ES6 supports fat-arrow methods with no `{}` (e.g. `() => 42`) which is
annoyingly difficult to export as cscope without something to attach the "end of
method" tag to.