### PR TITLE
Relax parser version requirement

### DIFF
--- a/starscope.gemspec
+++ b/starscope.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'oj', '~> 2.9'
-  gem.add_dependency 'parser', '~> 2.2.2'
+  gem.add_dependency 'parser', '>= 2.2.2'
   gem.add_dependency 'ruby-progressbar', '~> 1.5'
   gem.add_dependency 'rkelly-remix', '~> 0.0.7'
   gem.add_dependency 'babel-transpiler', '~> 0.7'


### PR DESCRIPTION
@iamcz this branch should hopefully avoid the dependency error when running with the parser pre-release version

ref: https://github.com/eapache/starscope/issues/148#issuecomment-164331435