### PR TITLE
js: be pickier recognizing `require` calls

### DIFF
--- a/lib/starscope/langs/javascript.rb
+++ b/lib/starscope/langs/javascript.rb
@@ -60,7 +60,7 @@ module Starscope::Lang
           name = node_name(node.value)
           next unless name
 
-          node = node.arguments.value[0] if name == 'require'
+          node = node.arguments.value[0] if name == 'require' && !node.value.is_a?(RKelly::Nodes::DotAccessorNode)
 
           line = find_line(node.range.from, map, lines, name)
           next unless line
@@ -68,7 +68,7 @@ module Starscope::Lang
           found[name] ||= Set.new
           found[name].add(line)
 
-          if name == 'require'
+          if name == 'require' && node.is_a?(RKelly::Nodes::StringNode)
             yield :requires, node.value[1...-1], line_no: line
           else
             yield :calls, name, line_no: line

--- a/test/fixtures/sample_javascript.js
+++ b/test/fixtures/sample_javascript.js
@@ -118,3 +118,6 @@ class Navigation extends Component {
 }
 
 export default Navigation;
+
+madness.require("NOPE")
+require(true || false);

--- a/test/unit/langs/javascript_test.rb
+++ b/test/unit/langs/javascript_test.rb
@@ -80,5 +80,8 @@ describe Starscope::Lang::Javascript do
 
     requires.keys.must_include :'foo-bar'
     requires.keys.must_include :'react-native'
+    requires.keys.wont_include :NOPE
+    requires.keys.wont_include :true
+    requires.keys.wont_include :false
   end
 end


### PR DESCRIPTION
Fix a crash when the parameter is not a string at all, and don't specially
recognize them when they're accessed on an object.