### PR TITLE
More rubocop changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
-Lint/UnusedMethodArgument:
-  Enabled: false
+AllCops:
+  Exclude:
+    - 'test/fixtures/sample_ruby.rb'
 
 Metrics/AbcSize:
   Enabled: false
@@ -25,15 +26,8 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Style/ClassAndModuleChildren:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
-
-Style/Next:
-  Exclude:
-    - 'test/fixtures/sample_ruby.rb'
 
 Style/SpecialGlobalVars:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 sudo: false
-cache: bundler
 
 rvm:
     - 1.9.3

--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -8,331 +8,333 @@ require 'starscope/fragment_extractor'
 require 'starscope/queryable'
 require 'starscope/output'
 
-class Starscope::DB
-  include Starscope::Exportable
-  include Starscope::Queryable
+module Starscope
+  class DB
+    include Starscope::Exportable
+    include Starscope::Queryable
 
-  DB_FORMAT = 5
-  FRAGMENT = :'!fragment'
+    DB_FORMAT = 5
+    FRAGMENT = :'!fragment'
 
-  # dynamically load all our language extractors
-  Dir.glob("#{File.dirname(__FILE__)}/langs/*.rb").each { |path| require path }
+    # dynamically load all our language extractors
+    Dir.glob("#{File.dirname(__FILE__)}/langs/*.rb").each { |path| require path }
 
-  langs = {}
-  extractors = []
-  Starscope::Lang.constants.each do |lang|
-    extractor = Starscope::Lang.const_get(lang)
-    extractors << extractor
-    langs[lang.to_sym] = extractor.const_get(:VERSION)
-  end
-  LANGS = langs.freeze
-  EXTRACTORS = extractors.freeze
-
-  class NoTableError < StandardError; end
-  class UnknownDBFormatError < StandardError; end
-
-  def initialize(output, config = {})
-    @output = output
-    @meta = { paths: [], files: {}, excludes: [],
-              langs: LANGS.dup, version: Starscope::VERSION }
-    @tables = {}
-    @config = config
-  end
-
-  # returns true iff the database was already in the most recent format
-  def load(filename)
-    @output.extra("Reading database from `#{filename}`... ")
-    current_fmt = open_db(filename)
-    fixup if current_fmt
-    current_fmt
-  end
-
-  def save(filename)
-    @output.extra("Writing database to `#{filename}`...")
-
-    # regardless of what the old version was, the new version is written by us
-    @meta[:version] = Starscope::VERSION
-
-    @meta[:langs].merge!(LANGS)
-
-    File.open(filename, 'w') do |file|
-      Zlib::GzipWriter.wrap(file) do |stream|
-        stream.puts DB_FORMAT
-        stream.puts Oj.dump @meta
-        stream.puts Oj.dump @tables
-      end
+    langs = {}
+    extractors = []
+    Starscope::Lang.constants.each do |lang|
+      extractor = Starscope::Lang.const_get(lang)
+      extractors << extractor
+      langs[lang.to_sym] = extractor.const_get(:VERSION)
     end
-  end
+    LANGS = langs.freeze
+    EXTRACTORS = extractors.freeze
 
-  def add_excludes(paths)
-    @output.extra("Excluding files in paths #{paths}...")
-    @meta[:paths] -= paths.map { |p| self.class.normalize_glob(p) }
-    paths = paths.map { |p| self.class.normalize_fnmatch(p) }
-    @meta[:excludes] += paths
-    @meta[:excludes].uniq!
-    @all_excludes = nil # clear cache
+    class NoTableError < StandardError; end
+    class UnknownDBFormatError < StandardError; end
 
-    excluded = @meta[:files].keys.select { |name| matches_exclude?(name, paths) }
-    remove_files(excluded)
-  end
-
-  def add_paths(paths)
-    @output.extra("Adding files in paths #{paths}...")
-    @meta[:excludes] -= paths.map { |p| self.class.normalize_fnmatch(p) }
-    @all_excludes = nil # clear cache
-    paths = paths.map { |p| self.class.normalize_glob(p) }
-    @meta[:paths] += paths
-    @meta[:paths].uniq!
-    files = Dir.glob(paths).select { |f| File.file? f }
-    files.delete_if { |f| matches_exclude?(f) }
-    return if files.empty?
-    @output.new_pbar('Building', files.length)
-    add_files(files)
-    @output.finish_pbar
-  end
-
-  def update
-    changes = @meta[:files].keys.group_by { |name| file_changed(name) }
-    changes[:modified] ||= []
-    changes[:deleted] ||= []
-
-    new_files = (Dir.glob(@meta[:paths]).select { |f| File.file? f }) - @meta[:files].keys
-    new_files.delete_if { |f| matches_exclude?(f) }
-
-    if changes[:deleted].empty? && changes[:modified].empty? && new_files.empty?
-      @output.normal('No changes detected.')
-      return false
+    def initialize(output, config = {})
+      @output = output
+      @meta = { paths: [], files: {}, excludes: [],
+                langs: LANGS.dup, version: Starscope::VERSION }
+      @tables = {}
+      @config = config
     end
 
-    @output.new_pbar('Updating', changes[:modified].length + new_files.length)
-    remove_files(changes[:deleted])
-    update_files(changes[:modified])
-    add_files(new_files)
-    @output.finish_pbar
+    # returns true iff the database was already in the most recent format
+    def load(filename)
+      @output.extra("Reading database from `#{filename}`... ")
+      current_fmt = open_db(filename)
+      fixup if current_fmt
+      current_fmt
+    end
 
-    true
-  end
+    def save(filename)
+      @output.extra("Writing database to `#{filename}`...")
 
-  def line_for_record(rec)
-    return rec[:line] if rec[:line]
+      # regardless of what the old version was, the new version is written by us
+      @meta[:version] = Starscope::VERSION
 
-    file = @meta[:files][rec[:file]]
+      @meta[:langs].merge!(LANGS)
 
-    return file[:lines][rec[:line_no] - 1] if file[:lines]
-  end
-
-  def tables
-    @tables.keys
-  end
-
-  def records(table)
-    raise NoTableError unless @tables[table]
-
-    @tables[table]
-  end
-
-  def metadata(key = nil)
-    return @meta.keys if key.nil?
-
-    raise NoTableError unless @meta[key]
-
-    @meta[key]
-  end
-
-  def drop_all
-    @meta[:files] = {}
-    @tables = {}
-  end
-
-  private
-
-  def open_db(filename)
-    File.open(filename, 'r') do |file|
-      begin
-        Zlib::GzipReader.wrap(file) do |stream|
-          parse_db(stream)
+      File.open(filename, 'w') do |file|
+        Zlib::GzipWriter.wrap(file) do |stream|
+          stream.puts DB_FORMAT
+          stream.puts Oj.dump @meta
+          stream.puts Oj.dump @tables
         end
-      rescue Zlib::GzipFile::Error
-        file.rewind
-        parse_db(file)
       end
     end
-  end
 
-  # returns true iff the database is in the most recent format
-  def parse_db(stream)
-    case stream.gets.to_i
-    when DB_FORMAT
-      @meta   = Oj.load(stream.gets)
-      @tables = Oj.load(stream.gets)
+    def add_excludes(paths)
+      @output.extra("Excluding files in paths #{paths}...")
+      @meta[:paths] -= paths.map { |p| self.class.normalize_glob(p) }
+      paths = paths.map { |p| self.class.normalize_fnmatch(p) }
+      @meta[:excludes] += paths
+      @meta[:excludes].uniq!
+      @all_excludes = nil # clear cache
+
+      excluded = @meta[:files].keys.select { |name| matches_exclude?(name, paths) }
+      remove_files(excluded)
+    end
+
+    def add_paths(paths)
+      @output.extra("Adding files in paths #{paths}...")
+      @meta[:excludes] -= paths.map { |p| self.class.normalize_fnmatch(p) }
+      @all_excludes = nil # clear cache
+      paths = paths.map { |p| self.class.normalize_glob(p) }
+      @meta[:paths] += paths
+      @meta[:paths].uniq!
+      files = Dir.glob(paths).select { |f| File.file? f }
+      files.delete_if { |f| matches_exclude?(f) }
+      return if files.empty?
+      @output.new_pbar('Building', files.length)
+      add_files(files)
+      @output.finish_pbar
+    end
+
+    def update
+      changes = @meta[:files].keys.group_by { |name| file_changed(name) }
+      changes[:modified] ||= []
+      changes[:deleted] ||= []
+
+      new_files = (Dir.glob(@meta[:paths]).select { |f| File.file? f }) - @meta[:files].keys
+      new_files.delete_if { |f| matches_exclude?(f) }
+
+      if changes[:deleted].empty? && changes[:modified].empty? && new_files.empty?
+        @output.normal('No changes detected.')
+        return false
+      end
+
+      @output.new_pbar('Updating', changes[:modified].length + new_files.length)
+      remove_files(changes[:deleted])
+      update_files(changes[:modified])
+      add_files(new_files)
+      @output.finish_pbar
+
+      true
+    end
+
+    def line_for_record(rec)
+      return rec[:line] if rec[:line]
+
+      file = @meta[:files][rec[:file]]
+
+      return file[:lines][rec[:line_no] - 1] if file[:lines]
+    end
+
+    def tables
+      @tables.keys
+    end
+
+    def records(table)
+      raise NoTableError unless @tables[table]
+
+      @tables[table]
+    end
+
+    def metadata(key = nil)
+      return @meta.keys if key.nil?
+
+      raise NoTableError unless @meta[key]
+
+      @meta[key]
+    end
+
+    def drop_all
+      @meta[:files] = {}
+      @tables = {}
+    end
+
+    private
+
+    def open_db(filename)
+      File.open(filename, 'r') do |file|
+        begin
+          Zlib::GzipReader.wrap(file) do |stream|
+            parse_db(stream)
+          end
+        rescue Zlib::GzipFile::Error
+          file.rewind
+          parse_db(file)
+        end
+      end
+    end
+
+    # returns true iff the database is in the most recent format
+    def parse_db(stream)
+      case stream.gets.to_i
+      when DB_FORMAT
+        @meta   = Oj.load(stream.gets)
+        @tables = Oj.load(stream.gets)
+        return true
+      when 3..4
+        # Old format, so read the directories segment then rebuild
+        add_paths(Oj.load(stream.gets))
+        return false
+      when 0..2
+        # Old format (pre-json), so read the directories segment then rebuild
+        len = stream.gets.to_i
+        add_paths(Marshal.load(stream.read(len)))
+        return false
+      else
+        raise UnknownDBFormatError
+      end
+    rescue Oj::ParseError
+      stream.rewind
+      raise unless stream.gets.to_i == DB_FORMAT
+      # try reading as formated json, which is much slower, but it is sometimes
+      # useful to be able to directly read your db
+      objects = []
+      Oj.load(stream) { |obj| objects << obj }
+      @meta, @tables = objects
       return true
-    when 3..4
-      # Old format, so read the directories segment then rebuild
-      add_paths(Oj.load(stream.gets))
-      return false
-    when 0..2
-      # Old format (pre-json), so read the directories segment then rebuild
-      len = stream.gets.to_i
-      add_paths(Marshal.load(stream.read(len)))
-      return false
-    else
-      raise UnknownDBFormatError
     end
-  rescue Oj::ParseError
-    stream.rewind
-    raise unless stream.gets.to_i == DB_FORMAT
-    # try reading as formated json, which is much slower, but it is sometimes
-    # useful to be able to directly read your db
-    objects = []
-    Oj.load(stream) { |obj| objects << obj }
-    @meta, @tables = objects
-    return true
-  end
 
-  def fixup
-    # misc things that were't worth bumping the format for, but which might not be written by old versions
-    @meta[:langs] ||= {}
-  end
-
-  def all_excludes
-    @all_excludes ||= @meta[:excludes] + (@config[:excludes] || []).map { |x| self.class.normalize_fnmatch(x) }
-  end
-
-  def matches_exclude?(file, patterns = all_excludes)
-    patterns.map { |p| File.fnmatch(p, file) }.any?
-  end
-
-  def add_files(files)
-    files.each do |file|
-      @output.extra("Adding `#{file}`")
-      parse_file(file)
-      @output.inc_pbar
+    def fixup
+      # misc things that were't worth bumping the format for, but which might not be written by old versions
+      @meta[:langs] ||= {}
     end
-  end
 
-  def remove_files(files)
-    files.each do |file|
-      @output.extra("Removing `#{file}`")
-      @meta[:files].delete(file)
+    def all_excludes
+      @all_excludes ||= @meta[:excludes] + (@config[:excludes] || []).map { |x| self.class.normalize_fnmatch(x) }
     end
-    files = files.to_set
-    @tables.each do |_, tbl|
-      tbl.delete_if { |val| files.include?(val[:file]) }
+
+    def matches_exclude?(file, patterns = all_excludes)
+      patterns.map { |p| File.fnmatch(p, file) }.any?
     end
-  end
 
-  def update_files(files)
-    remove_files(files)
-    add_files(files)
-  end
-
-  def parse_file(file)
-    @meta[:files][file] = { last_updated: File.mtime(file).to_i }
-
-    self.class.extractors.each do |extractor|
-      begin
-        next unless extractor.match_file file
-      rescue => e
-        @output.normal("#{extractor} raised \"#{e}\" while matching #{file}")
-        next
+    def add_files(files)
+      files.each do |file|
+        @output.extra("Adding `#{file}`")
+        parse_file(file)
+        @output.inc_pbar
       end
-
-      line_cache = File.readlines(file)
-      lines = Array.new(line_cache.length)
-      @meta[:files][file][:sublangs] = []
-      extract_file(extractor, file, line_cache, lines)
-
-      break
     end
-  end
 
-  def extract_file(extractor, file, line_cache, lines)
-    fragment_cache = {}
+    def remove_files(files)
+      files.each do |file|
+        @output.extra("Removing `#{file}`")
+        @meta[:files].delete(file)
+      end
+      files = files.to_set
+      @tables.each do |_, tbl|
+        tbl.delete_if { |val| files.include?(val[:file]) }
+      end
+    end
 
-    extractor_metadata = extractor.extract(file, File.read(file)) do |tbl, name, args|
-      case tbl
-      when FRAGMENT
-        fragment_cache[name] ||= []
-        fragment_cache[name] << args
-      else
-        @tables[tbl] ||= []
-        @tables[tbl] << self.class.normalize_record(file, name, args)
+    def update_files(files)
+      remove_files(files)
+      add_files(files)
+    end
 
-        if args[:line_no]
-          line_cache ||= File.readlines(file)
-          lines ||= Array.new(line_cache.length)
-          lines[args[:line_no] - 1] = line_cache[args[:line_no] - 1].chomp
+    def parse_file(file)
+      @meta[:files][file] = { last_updated: File.mtime(file).to_i }
+
+      self.class.extractors.each do |extractor|
+        begin
+          next unless extractor.match_file file
+        rescue => e
+          @output.normal("#{extractor} raised \"#{e}\" while matching #{file}")
+          next
+        end
+
+        line_cache = File.readlines(file)
+        lines = Array.new(line_cache.length)
+        @meta[:files][file][:sublangs] = []
+        extract_file(extractor, file, line_cache, lines)
+
+        break
+      end
+    end
+
+    def extract_file(extractor, file, line_cache, lines)
+      fragment_cache = {}
+
+      extractor_metadata = extractor.extract(file, File.read(file)) do |tbl, name, args|
+        case tbl
+        when FRAGMENT
+          fragment_cache[name] ||= []
+          fragment_cache[name] << args
+        else
+          @tables[tbl] ||= []
+          @tables[tbl] << self.class.normalize_record(file, name, args)
+
+          if args[:line_no]
+            line_cache ||= File.readlines(file)
+            lines ||= Array.new(line_cache.length)
+            lines[args[:line_no] - 1] = line_cache[args[:line_no] - 1].chomp
+          end
         end
       end
+
+      fragment_cache.each do |lang, frags|
+        extract_file(Starscope::FragmentExtractor.new(lang, frags), file, line_cache, lines)
+        @meta[:files][file][:sublangs] << lang
+      end
+
+      @meta[:files][file][:lang] = extractor.name.split('::').last.to_sym
+      @meta[:files][file][:lines] = lines
+
+      if extractor_metadata.is_a? Hash
+        @meta[:files][file] = extractor_metadata.merge!(@meta[:files][file])
+      end
+
+    rescue => e
+      @output.normal("#{extractor} raised \"#{e}\" while extracting #{file}")
     end
 
-    fragment_cache.each do |lang, frags|
-      extract_file(Starscope::FragmentExtractor.new(lang, frags), file, line_cache, lines)
-      @meta[:files][file][:sublangs] << lang
-    end
-
-    @meta[:files][file][:lang] = extractor.name.split('::').last.to_sym
-    @meta[:files][file][:lines] = lines
-
-    if extractor_metadata.is_a? Hash
-      @meta[:files][file] = extractor_metadata.merge!(@meta[:files][file])
-    end
-
-  rescue => e
-    @output.normal("#{extractor} raised \"#{e}\" while extracting #{file}")
-  end
-
-  def file_changed(name)
-    file_meta = @meta[:files][name]
-    if matches_exclude?(name) || !File.exist?(name) || !File.file?(name)
-      :deleted
-    elsif (file_meta[:last_updated] < File.mtime(name).to_i) ||
-          language_out_of_date(file_meta[:lang]) ||
-          (file_meta[:sublangs] || []).any? { |lang| language_out_of_date(lang) }
-      :modified
-    else
-      :unchanged
-    end
-  end
-
-  def language_out_of_date(lang)
-    return false unless lang
-    return true unless LANGS[lang]
-    (@meta[:langs][lang] || 0) < LANGS[lang]
-  end
-
-  class << self
-    # File.fnmatch treats a "**" to match files and directories recursively
-    def normalize_fnmatch(path)
-      if path == '.'
-        '**'
-      elsif File.directory?(path)
-        File.join(path, '**')
+    def file_changed(name)
+      file_meta = @meta[:files][name]
+      if matches_exclude?(name) || !File.exist?(name) || !File.file?(name)
+        :deleted
+      elsif (file_meta[:last_updated] < File.mtime(name).to_i) ||
+            language_out_of_date(file_meta[:lang]) ||
+            (file_meta[:sublangs] || []).any? { |lang| language_out_of_date(lang) }
+        :modified
       else
-        path
+        :unchanged
       end
     end
 
-    # Dir.glob treats a "**" to only match directories recursively; you need
-    # "**/*" to match all files recursively
-    def normalize_glob(path)
-      if path == '.'
-        File.join('**', '*')
-      elsif File.directory?(path)
-        File.join(path, '**', '*')
-      else
-        path
+    def language_out_of_date(lang)
+      return false unless lang
+      return true unless LANGS[lang]
+      (@meta[:langs][lang] || 0) < LANGS[lang]
+    end
+
+    class << self
+      # File.fnmatch treats a "**" to match files and directories recursively
+      def normalize_fnmatch(path)
+        if path == '.'
+          '**'
+        elsif File.directory?(path)
+          File.join(path, '**')
+        else
+          path
+        end
       end
-    end
 
-    def normalize_record(file, name, args)
-      args[:file] = file
-      args[:name] = Array(name).map(&:to_sym)
-      args
-    end
+      # Dir.glob treats a "**" to only match directories recursively; you need
+      # "**/*" to match all files recursively
+      def normalize_glob(path)
+        if path == '.'
+          File.join('**', '*')
+        elsif File.directory?(path)
+          File.join(path, '**', '*')
+        else
+          path
+        end
+      end
 
-    def extractors # so we can stub it in tests
-      EXTRACTORS
+      def normalize_record(file, name, args)
+        args[:file] = file
+        args[:name] = Array(name).map(&:to_sym)
+        args
+      end
+
+      def extractors # so we can stub it in tests
+        EXTRACTORS
+      end
     end
   end
 end

--- a/lib/starscope/exportable.rb
+++ b/lib/starscope/exportable.rb
@@ -1,41 +1,42 @@
-module Starscope::Exportable
-  CTAGS_DEFAULT_PATH = 'tags'.freeze
-  CSCOPE_DEFAULT_PATH = 'cscope.out'.freeze
+module Starscope
+  module Exportable
+    CTAGS_DEFAULT_PATH = 'tags'.freeze
+    CSCOPE_DEFAULT_PATH = 'cscope.out'.freeze
 
-  class UnknownExportFormatError < StandardError; end
+    class UnknownExportFormatError < StandardError; end
 
-  def export(format, path = nil)
-    case format
-    when :ctags
-      path ||= CTAGS_DEFAULT_PATH
-    when :cscope
-      path ||= CSCOPE_DEFAULT_PATH
-    else
-      raise UnknownExportFormatError
+    def export(format, path = nil)
+      case format
+      when :ctags
+        path ||= CTAGS_DEFAULT_PATH
+      when :cscope
+        path ||= CSCOPE_DEFAULT_PATH
+      else
+        raise UnknownExportFormatError
+      end
+
+      @output.normal("Exporting to '#{path}' in format '#{format}'...")
+      File.open(path, 'w') do |file|
+        export_to(format, file)
+      end
+      @output.normal('Export complete.')
     end
 
-    @output.normal("Exporting to '#{path}' in format '#{format}'...")
-    File.open(path, 'w') do |file|
-      export_to(format, file)
+    def export_to(format, io)
+      case format
+      when :ctags
+        export_ctags(io)
+      when :cscope
+        export_cscope(io)
+      else
+        raise UnknownExportFormatError
+      end
     end
-    @output.normal('Export complete.')
-  end
 
-  def export_to(format, io)
-    case format
-    when :ctags
-      export_ctags(io)
-    when :cscope
-      export_cscope(io)
-    else
-      raise UnknownExportFormatError
-    end
-  end
+    private
 
-  private
-
-  def export_ctags(file)
-    file.puts <<END
+    def export_ctags(file)
+      file.puts <<END
 !_TAG_FILE_FORMAT	2	/extended format/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
 !_TAG_PROGRAM_AUTHOR	Evan Huus /eapache@gmail.com/
@@ -43,240 +44,241 @@ module Starscope::Exportable
 !_TAG_PROGRAM_URL	https://github.com/eapache/starscope //
 !_TAG_PROGRAM_VERSION	#{Starscope::VERSION}	//
 END
-    defs = (@tables[:defs] || {}).sort_by { |x| x[:name][-1].to_s }
-    defs.each do |record|
-      file.puts ctag_line(record, @meta[:files][record[:file]])
-    end
-  end
-
-  def ctag_line(rec, file)
-    line = line_for_record(rec).gsub('/', '\/')
-    ret = "#{rec[:name][-1]}\t#{rec[:file]}\t/^#{line}$/"
-
-    ext = ctag_ext_tags(rec, file)
-    unless ext.empty?
-      ret << ';"'
-      ext.sort.each do |k, v|
-        ret << "\t#{k}:#{v}"
+      defs = (@tables[:defs] || {}).sort_by { |x| x[:name][-1].to_s }
+      defs.each do |record|
+        file.puts ctag_line(record, @meta[:files][record[:file]])
       end
     end
 
-    ret
-  end
+    def ctag_line(rec, file)
+      line = line_for_record(rec).gsub('/', '\/')
+      ret = "#{rec[:name][-1]}\t#{rec[:file]}\t/^#{line}$/"
 
-  def ctag_ext_tags(rec, file)
-    tag = {}
-
-    # these extensions are documented at http://ctags.sourceforge.net/FORMAT
-    case rec[:type]
-    when :func
-      tag['kind'] = 'f'
-    when :module, :class
-      tag['kind'] = 'c'
-    end
-
-    tag['language'] = file[:lang]
-
-    tag
-  end
-
-  # cscope has this funky issue where it refuses to recognize function calls that
-  # happen outside of a function definition - this isn't an issue in C, where all
-  # calls must occur in a function, but in ruby et al. it is perfectly legal to
-  # write normal code outside the "scope" of a function definition - we insert a
-  # fake shim "global" function everywhere we can to work around this
-  CSCOPE_GLOBAL_HACK_START = " \n\t$-\n".freeze
-  CSCOPE_GLOBAL_HACK_STOP = " \n\t}\n".freeze
-
-  # ftp://ftp.eeng.dcu.ie/pub/ee454/cygwin/usr/share/doc/mlcscope-14.1.8/html/cscope.html
-  def export_cscope(file)
-    buf = ''
-    files = []
-    db_by_line.each do |filename, lines|
-      next if lines.empty?
-
-      buf << "\t@#{filename}\n\n"
-      buf << "0 #{CSCOPE_GLOBAL_HACK_START}\n"
-      files << filename
-      func_count = 0
-
-      lines.sort.each do |line_no, records|
-        line = line_for_record(records.first)
-        toks = tokenize_line(line, records)
-        next if toks.empty?
-
-        prev = 0
-        buf << line_no.to_s << ' '
-        toks.each do |offset, record|
-          next if offset < prev # this probably indicates an extractor bug
-
-          # Don't export nested functions, cscope barfs on them since C doesn't
-          # have them at all. Skipping tokens is easy; since prev isn't updated
-          # they get turned into plain text automatically.
-          if record[:type] == :func
-            case record[:tbl]
-            when :defs
-              func_count += 1
-              next unless func_count == 1
-            when :end
-              func_count -= 1
-              next unless func_count == 0
-            end
-          end
-
-          buf << cscope_output(line, prev, offset, record)
-          prev = offset + record[:key].length
+      ext = ctag_ext_tags(rec, file)
+      unless ext.empty?
+        ret << ';"'
+        ext.sort.each do |k, v|
+          ret << "\t#{k}:#{v}"
         end
-        buf << cscope_plaintext(line, prev, line.length) << "\n\n"
       end
+
+      ret
     end
 
-    buf << "\t@\n"
+    def ctag_ext_tags(rec, file)
+      tag = {}
 
-    header = "cscope 15 #{Dir.pwd} -c "
-    offset = format("%010d\n", header.length + 11 + buf.bytes.count)
-
-    file.print(header)
-    file.print(offset)
-    file.print(buf)
-
-    file.print("#{@meta[:paths].length}\n")
-    @meta[:paths].each { |p| file.print("#{p}\n") }
-    file.print("0\n")
-    file.print("#{files.length}\n")
-    buf = ''
-    files.each { |f| buf << f + "\n" }
-    file.print("#{buf.length}\n#{buf}")
-  end
-
-  def db_by_line
-    db = {}
-    @tables.each do |tbl, records|
-      records.each do |record|
-        next unless record[:line_no]
-        record[:tbl] = tbl
-        db[record[:file]] ||= {}
-        db[record[:file]][record[:line_no]] ||= []
-        db[record[:file]][record[:line_no]] << record
-      end
-    end
-    db
-  end
-
-  def tokenize_line(line, records)
-    toks = {}
-
-    records.each do |record|
-      key = record[:name][-1].to_s
-
-      # use the column if we have it, otherwise fall back to scanning
-      index = record[:col] || line.index(key)
-
-      while index && !valid_index?(line, index, key)
-        index = line.index(key, index + 1)
-      end
-
-      next if index.nil?
-
-      # Strip trailing non-word characters, otherwise cscope barfs on
-      # function names like `include?`
-      if key =~ /^\W*$/
-        next unless [:defs, :end].include?(record[:tbl])
-      else
-        key.sub!(/\W+$/, '')
-      end
-
-      record[:key] = key
-      toks[index] = record
-    end
-
-    toks.sort
-  end
-
-  def cscope_output(line, prev, offset, record)
-    buf = ''
-    buf << CSCOPE_GLOBAL_HACK_STOP if record[:type] == :func && record[:tbl] == :defs
-
-    record[:name][0...-1].each do |key|
-      # output previous components of the name (ie the Foo in Foo::bar) as unmarked symbols
-      key = key.to_s.sub(/\W+$/, '')
-      next if key.empty?
-
-      index = line.index(key, prev)
-
-      while index && index + key.length < offset && !valid_index?(line, index, key)
-        index = line.index(key, index + 1)
-      end
-
-      next unless index && index + key.length < offset
-
-      buf << cscope_plaintext(line, prev, index) << "\n"
-      buf << "#{key}\n"
-      prev = index + key.length
-    end
-
-    buf << cscope_plaintext(line, prev, offset) << "\n"
-    buf << cscope_mark(record) << record[:key] << "\n"
-
-    buf << CSCOPE_GLOBAL_HACK_START if record[:type] == :func && record[:tbl] == :end
-    buf
-  rescue ArgumentError
-    # invalid utf-8 byte sequence in the line, oh well
-    line
-  end
-
-  def valid_index?(line, index, key)
-    # index is valid if the key exists at it, and the prev/next chars are not word characters
-    ((line[index, key.length] == key) &&
-     (index == 0 || line[index - 1] !~ /[[:word:]]/) &&
-     (index + key.length == line.length || line[index + key.length] !~ /[[:word:]]/))
-  end
-
-  def cscope_plaintext(line, start, stop)
-    ret = line.slice(start, stop - start)
-    ret.lstrip! if start == 0
-    ret.rstrip! if stop == line.length
-    ret.gsub!(/\s+/, ' ')
-    ret.empty? ? ' ' : ret
-  rescue ArgumentError
-    # invalid utf-8 byte sequence in the line, oh well
-    line
-  end
-
-  def cscope_mark(rec)
-    case rec[:tbl]
-    when :end
+      # these extensions are documented at http://ctags.sourceforge.net/FORMAT
       case rec[:type]
       when :func
-        ret = '}'
+        tag['kind'] = 'f'
+      when :module, :class
+        tag['kind'] = 'c'
+      end
+
+      tag['language'] = file[:lang]
+
+      tag
+    end
+
+    # cscope has this funky issue where it refuses to recognize function calls that
+    # happen outside of a function definition - this isn't an issue in C, where all
+    # calls must occur in a function, but in ruby et al. it is perfectly legal to
+    # write normal code outside the "scope" of a function definition - we insert a
+    # fake shim "global" function everywhere we can to work around this
+    CSCOPE_GLOBAL_HACK_START = " \n\t$-\n".freeze
+    CSCOPE_GLOBAL_HACK_STOP = " \n\t}\n".freeze
+
+    # ftp://ftp.eeng.dcu.ie/pub/ee454/cygwin/usr/share/doc/mlcscope-14.1.8/html/cscope.html
+    def export_cscope(file)
+      buf = ''
+      files = []
+      db_by_line.each do |filename, lines|
+        next if lines.empty?
+
+        buf << "\t@#{filename}\n\n"
+        buf << "0 #{CSCOPE_GLOBAL_HACK_START}\n"
+        files << filename
+        func_count = 0
+
+        lines.sort.each do |line_no, records|
+          line = line_for_record(records.first)
+          toks = tokenize_line(line, records)
+          next if toks.empty?
+
+          prev = 0
+          buf << line_no.to_s << ' '
+          toks.each do |offset, record|
+            next if offset < prev # this probably indicates an extractor bug
+
+            # Don't export nested functions, cscope barfs on them since C doesn't
+            # have them at all. Skipping tokens is easy; since prev isn't updated
+            # they get turned into plain text automatically.
+            if record[:type] == :func
+              case record[:tbl]
+              when :defs
+                func_count += 1
+                next unless func_count == 1
+              when :end
+                func_count -= 1
+                next unless func_count == 0
+              end
+            end
+
+            buf << cscope_output(line, prev, offset, record)
+            prev = offset + record[:key].length
+          end
+          buf << cscope_plaintext(line, prev, line.length) << "\n\n"
+        end
+      end
+
+      buf << "\t@\n"
+
+      header = "cscope 15 #{Dir.pwd} -c "
+      offset = format("%010d\n", header.length + 11 + buf.bytes.count)
+
+      file.print(header)
+      file.print(offset)
+      file.print(buf)
+
+      file.print("#{@meta[:paths].length}\n")
+      @meta[:paths].each { |p| file.print("#{p}\n") }
+      file.print("0\n")
+      file.print("#{files.length}\n")
+      buf = ''
+      files.each { |f| buf << f + "\n" }
+      file.print("#{buf.length}\n#{buf}")
+    end
+
+    def db_by_line
+      db = {}
+      @tables.each do |tbl, records|
+        records.each do |record|
+          next unless record[:line_no]
+          record[:tbl] = tbl
+          db[record[:file]] ||= {}
+          db[record[:file]][record[:line_no]] ||= []
+          db[record[:file]][record[:line_no]] << record
+        end
+      end
+      db
+    end
+
+    def tokenize_line(line, records)
+      toks = {}
+
+      records.each do |record|
+        key = record[:name][-1].to_s
+
+        # use the column if we have it, otherwise fall back to scanning
+        index = record[:col] || line.index(key)
+
+        while index && !valid_index?(line, index, key)
+          index = line.index(key, index + 1)
+        end
+
+        next if index.nil?
+
+        # Strip trailing non-word characters, otherwise cscope barfs on
+        # function names like `include?`
+        if key =~ /^\W*$/
+          next unless [:defs, :end].include?(record[:tbl])
+        else
+          key.sub!(/\W+$/, '')
+        end
+
+        record[:key] = key
+        toks[index] = record
+      end
+
+      toks.sort
+    end
+
+    def cscope_output(line, prev, offset, record)
+      buf = ''
+      buf << CSCOPE_GLOBAL_HACK_STOP if record[:type] == :func && record[:tbl] == :defs
+
+      record[:name][0...-1].each do |key|
+        # output previous components of the name (ie the Foo in Foo::bar) as unmarked symbols
+        key = key.to_s.sub(/\W+$/, '')
+        next if key.empty?
+
+        index = line.index(key, prev)
+
+        while index && index + key.length < offset && !valid_index?(line, index, key)
+          index = line.index(key, index + 1)
+        end
+
+        next unless index && index + key.length < offset
+
+        buf << cscope_plaintext(line, prev, index) << "\n"
+        buf << "#{key}\n"
+        prev = index + key.length
+      end
+
+      buf << cscope_plaintext(line, prev, offset) << "\n"
+      buf << cscope_mark(record) << record[:key] << "\n"
+
+      buf << CSCOPE_GLOBAL_HACK_START if record[:type] == :func && record[:tbl] == :end
+      buf
+    rescue ArgumentError
+      # invalid utf-8 byte sequence in the line, oh well
+      line
+    end
+
+    def valid_index?(line, index, key)
+      # index is valid if the key exists at it, and the prev/next chars are not word characters
+      ((line[index, key.length] == key) &&
+       (index == 0 || line[index - 1] !~ /[[:word:]]/) &&
+       (index + key.length == line.length || line[index + key.length] !~ /[[:word:]]/))
+    end
+
+    def cscope_plaintext(line, start, stop)
+      ret = line.slice(start, stop - start)
+      ret.lstrip! if start == 0
+      ret.rstrip! if stop == line.length
+      ret.gsub!(/\s+/, ' ')
+      ret.empty? ? ' ' : ret
+    rescue ArgumentError
+      # invalid utf-8 byte sequence in the line, oh well
+      line
+    end
+
+    def cscope_mark(rec)
+      case rec[:tbl]
+      when :end
+        case rec[:type]
+        when :func
+          ret = '}'
+        else
+          return ''
+        end
+      when :file
+        ret = '@'
+      when :defs
+        case rec[:type]
+        when :func
+          ret = '$'
+        when :class, :module
+          ret = 'c'
+        when :type
+          ret = 't'
+        else
+          ret = 'g'
+        end
+      when :calls
+        ret = '`'
+      when :requires
+        ret = '~"'
+      when :imports
+        ret = '~<'
+      when :assigns
+        ret = '='
       else
         return ''
       end
-    when :file
-      ret = '@'
-    when :defs
-      case rec[:type]
-      when :func
-        ret = '$'
-      when :class, :module
-        ret = 'c'
-      when :type
-        ret = 't'
-      else
-        ret = 'g'
-      end
-    when :calls
-      ret = '`'
-    when :requires
-      ret = '~"'
-    when :imports
-      ret = '~<'
-    when :assigns
-      ret = '='
-    else
-      return ''
-    end
 
-    "\t" + ret
+      "\t" + ret
+    end
   end
 end

--- a/lib/starscope/fragment_extractor.rb
+++ b/lib/starscope/fragment_extractor.rb
@@ -1,22 +1,24 @@
-class Starscope::FragmentExtractor
-  def initialize(lang, frags)
-    @child = Starscope::Lang.const_get(lang)
-    @frags = frags
-  end
-
-  def extract(path, text)
-    text = @frags.map { |f| f.delete(:frag).strip }.join("\n")
-
-    extractor_metadata = @child.extract(path, text) do |tbl, name, args|
-      args.merge!(@frags[args[:line_no] - 1]) if args[:line_no]
-      yield tbl, name, args
+module Starscope
+  class FragmentExtractor
+    def initialize(lang, frags)
+      @child = Starscope::Lang.const_get(lang)
+      @frags = frags
     end
 
-    # TODO: translate metadata?
-    extractor_metadata
-  end
+    def extract(path, text)
+      text = @frags.map { |f| f.delete(:frag).strip }.join("\n")
 
-  def name
-    @child.name
+      extractor_metadata = @child.extract(path, text) do |tbl, name, args|
+        args.merge!(@frags[args[:line_no] - 1]) if args[:line_no]
+        yield tbl, name, args
+      end
+
+      # TODO: translate metadata?
+      extractor_metadata
+    end
+
+    def name
+      @child.name
+    end
   end
 end

--- a/lib/starscope/langs/golang.rb
+++ b/lib/starscope/langs/golang.rb
@@ -1,206 +1,208 @@
-module Starscope::Lang
-  module Golang
-    VERSION = 1
+module Starscope
+  module Lang
+    module Golang
+      VERSION = 1
 
-    FUNC_CALL = /([\w\.]*?\w)\(/
-    END_OF_BLOCK = /^\s*\}\s*$/
-    END_OF_GROUP = /^\s*\)\s*$/
-    STRING_LITERAL = /".+?"/
-    BUILTIN_FUNCS = %w(new make len close copy delete int int8 int16 int32 int64
-                       uint uint8 uint16 uint32 uint64 string byte).freeze
-    CONTROL_KEYS = %w(if for switch case).freeze
+      FUNC_CALL = /([\w\.]*?\w)\(/
+      END_OF_BLOCK = /^\s*\}\s*$/
+      END_OF_GROUP = /^\s*\)\s*$/
+      STRING_LITERAL = /".+?"/
+      BUILTIN_FUNCS = %w(new make len close copy delete int int8 int16 int32 int64
+                         uint uint8 uint16 uint32 uint64 string byte).freeze
+      CONTROL_KEYS = %w(if for switch case).freeze
 
-    def self.match_file(name)
-      name.end_with?('.go')
-    end
+      def self.match_file(name)
+        name.end_with?('.go')
+      end
 
-    def self.extract(path, contents, &block)
-      stack = []
-      scope = []
-      contents.lines.each_with_index do |line, line_no|
-        line_no += 1 # zero-index to one-index
+      def self.extract(_path, contents, &block)
+        stack = []
+        scope = []
+        contents.lines.each_with_index do |line, line_no|
+          line_no += 1 # zero-index to one-index
 
-        # strip single-line comments like // foo
-        match = %r{//}.match(line)
-        line = match.pre_match if match
-        # strip single-line comments like foo /* foo */ foo
-        match = %r{/\*.*\*/}.match(line)
-        line = match.pre_match + match.post_match if match
-        # strip end-of-line comment starters like foo /* foo \n
-        match = %r{/\*}.match(line)
-        line = match.pre_match if match
-        ends_with_comment = !match.nil?
+          # strip single-line comments like // foo
+          match = %r{//}.match(line)
+          line = match.pre_match if match
+          # strip single-line comments like foo /* foo */ foo
+          match = %r{/\*.*\*/}.match(line)
+          line = match.pre_match + match.post_match if match
+          # strip end-of-line comment starters like foo /* foo \n
+          match = %r{/\*}.match(line)
+          line = match.pre_match if match
+          ends_with_comment = !match.nil?
 
-        # if we're in a block comment, wait for it to end
-        if stack[-1] == :comment
-          match = %r{\*/(.*)}.match(line)
-          next unless match
-          line = match[1]
-          stack.pop
-        end
-
-        if stack[-1] != :import && !line.start_with?('import')
-          # strip string literals like "foo" unless they're part of an import
-          pos = 0
-          while (match = STRING_LITERAL.match(line, pos))
-            eos = find_end_of_string(line, match.begin(0))
-            line = line[0..match.begin(0)] + line[eos..-1]
-            pos = match.begin(0) + 2
-          end
-        end
-
-        # poor-man's parser
-        case stack[-1]
-        when :struct
-          case line
-          when END_OF_BLOCK
-            end_block(line_no, scope, stack, &block)
-          when /(.+)\s+\w+/
-            parse_def(Regexp.last_match(1), line_no, scope, &block)
-          end
-        when :interface
-          case line
-          when END_OF_BLOCK
-            end_block(line_no, scope, stack, &block)
-          when /(\w+)\(.*\)\s+/
-            yield :defs, scope + [Regexp.last_match(1)], line_no: line_no
-          end
-        when :def
-          case line
-          when END_OF_GROUP
+          # if we're in a block comment, wait for it to end
+          if stack[-1] == :comment
+            match = %r{\*/(.*)}.match(line)
+            next unless match
+            line = match[1]
             stack.pop
-          when /(.+)\s*=.*/
-            parse_def(Regexp.last_match(1), line_no, scope, &block)
-            parse_call(line, line_no, scope, &block)
-          else
-            parse_def(line, line_no, scope, &block)
           end
-        when :import
-          case line
-          when END_OF_GROUP
-            stack.pop
-          when /"(.+)"/
-            name = Regexp.last_match(1).split('/')
-            yield :imports, name, line_no: line_no
+
+          if stack[-1] != :import && !line.start_with?('import')
+            # strip string literals like "foo" unless they're part of an import
+            pos = 0
+            while (match = STRING_LITERAL.match(line, pos))
+              eos = find_end_of_string(line, match.begin(0))
+              line = line[0..match.begin(0)] + line[eos..-1]
+              pos = match.begin(0) + 2
+            end
           end
-        when :func
-          case line
-          when /^\}/
-            yield :end, '}', line_no: line_no, type: :func
-            stack.pop
+
+          # poor-man's parser
+          case stack[-1]
+          when :struct
+            case line
+            when END_OF_BLOCK
+              end_block(line_no, scope, stack, &block)
+            when /(.+)\s+\w+/
+              parse_def(Regexp.last_match(1), line_no, scope, &block)
+            end
+          when :interface
+            case line
+            when END_OF_BLOCK
+              end_block(line_no, scope, stack, &block)
+            when /(\w+)\(.*\)\s+/
+              yield :defs, scope + [Regexp.last_match(1)], line_no: line_no
+            end
+          when :def
+            case line
+            when END_OF_GROUP
+              stack.pop
+            when /(.+)\s*=.*/
+              parse_def(Regexp.last_match(1), line_no, scope, &block)
+              parse_call(line, line_no, scope, &block)
+            else
+              parse_def(line, line_no, scope, &block)
+            end
+          when :import
+            case line
+            when END_OF_GROUP
+              stack.pop
+            when /"(.+)"/
+              name = Regexp.last_match(1).split('/')
+              yield :imports, name, line_no: line_no
+            end
+          when :func
+            case line
+            when /^\}/
+              yield :end, '}', line_no: line_no, type: :func
+              stack.pop
+            else
+              parse_new_line(line, line_no, scope, stack, &block)
+            end
           else
             parse_new_line(line, line_no, scope, stack, &block)
           end
-        else
-          parse_new_line(line, line_no, scope, stack, &block)
+
+          # if the line looks like "foo /* foo" then we enter the comment state
+          # after parsing the usable part of the line
+          stack.push(:comment) if ends_with_comment
         end
-
-        # if the line looks like "foo /* foo" then we enter the comment state
-        # after parsing the usable part of the line
-        stack.push(:comment) if ends_with_comment
       end
-    end
 
-    # handles new lines (when not in the middle of an existing definition)
-    def self.parse_new_line(line, line_no, scope, stack, &block)
-      case line
-      when /^func\s+(\w+)\(/
-        yield :defs, scope + [Regexp.last_match(1)], line_no: line_no, type: :func
-        stack.push(:func)
-      when /^func\s+\(\w+\s+\*?(\w+)\)\s*(\w+)\(/
-        yield :defs, scope + [Regexp.last_match(1), Regexp.last_match(2)], line_no: line_no, type: :func
-        stack.push(:func)
-      when /^package\s+(\w+)/
-        scope.push(Regexp.last_match(1))
-        yield :defs, scope, line_no: line_no, type: :package
-      when /^type\s+(\w+)\s+struct\s*\{/
-        scope.push(Regexp.last_match(1))
-        stack.push(:struct)
-        yield :defs, scope, line_no: line_no, type: :class
-      when /^type\s+(\w+)\s+interface\s*\{/
-        scope.push(Regexp.last_match(1))
-        stack.push(:interface)
-        yield :defs, scope, line_no: line_no, type: :class
-      when /^type\s+(\w+)/
-        yield :defs, scope + [Regexp.last_match(1)], line_no: line_no, type: :type
-      when /^import\s+"(.+)"/
-        name = Regexp.last_match(1).split('/')
-        yield :imports, name, line_no: line_no
-      when /^import\s+\(/
-        stack.push(:import)
-      when /^var\s+\(/
-        stack.push(:def)
-      when /^var\s+(\w+)\s/
-        yield :defs, scope + [Regexp.last_match(1)], line_no: line_no
-        parse_call(line, line_no, scope, &block)
-      when /^const\s+\(/
-        stack.push(:def)
-      when /^const\s+(\w+)\s/
-        yield :defs, scope + [Regexp.last_match(1)], line_no: line_no
-        parse_call(line, line_no, scope, &block)
-      when /^\s+(.*?) :?=[^=]/
-        Regexp.last_match(1).split(' ').each do |var|
-          next if CONTROL_KEYS.include?(var)
-          name = var.delete(',').split('.')
-          next if name[0] == '_' # assigning to _ is a discard in golang
+      # handles new lines (when not in the middle of an existing definition)
+      def self.parse_new_line(line, line_no, scope, stack, &block)
+        case line
+        when /^func\s+(\w+)\(/
+          yield :defs, scope + [Regexp.last_match(1)], line_no: line_no, type: :func
+          stack.push(:func)
+        when /^func\s+\(\w+\s+\*?(\w+)\)\s*(\w+)\(/
+          yield :defs, scope + [Regexp.last_match(1), Regexp.last_match(2)], line_no: line_no, type: :func
+          stack.push(:func)
+        when /^package\s+(\w+)/
+          scope.push(Regexp.last_match(1))
+          yield :defs, scope, line_no: line_no, type: :package
+        when /^type\s+(\w+)\s+struct\s*\{/
+          scope.push(Regexp.last_match(1))
+          stack.push(:struct)
+          yield :defs, scope, line_no: line_no, type: :class
+        when /^type\s+(\w+)\s+interface\s*\{/
+          scope.push(Regexp.last_match(1))
+          stack.push(:interface)
+          yield :defs, scope, line_no: line_no, type: :class
+        when /^type\s+(\w+)/
+          yield :defs, scope + [Regexp.last_match(1)], line_no: line_no, type: :type
+        when /^import\s+"(.+)"/
+          name = Regexp.last_match(1).split('/')
+          yield :imports, name, line_no: line_no
+        when /^import\s+\(/
+          stack.push(:import)
+        when /^var\s+\(/
+          stack.push(:def)
+        when /^var\s+(\w+)\s/
+          yield :defs, scope + [Regexp.last_match(1)], line_no: line_no
+          parse_call(line, line_no, scope, &block)
+        when /^const\s+\(/
+          stack.push(:def)
+        when /^const\s+(\w+)\s/
+          yield :defs, scope + [Regexp.last_match(1)], line_no: line_no
+          parse_call(line, line_no, scope, &block)
+        when /^\s+(.*?) :?=[^=]/
+          Regexp.last_match(1).split(' ').each do |var|
+            next if CONTROL_KEYS.include?(var)
+            name = var.delete(',').split('.')
+            next if name[0] == '_' # assigning to _ is a discard in golang
+            if name.length == 1
+              yield :assigns, scope + [name[0]], line_no: line_no
+            else
+              yield :assigns, name, line_no: line_no
+            end
+          end
+          parse_call(line, line_no, scope, &block)
+        else
+          parse_call(line, line_no, scope, &block)
+        end
+      end
+
+      def self.parse_call(line, line_no, scope)
+        line.scan(FUNC_CALL) do |match|
+          name = match[0].split('.').select { |chunk| !chunk.empty? }
           if name.length == 1
-            yield :assigns, scope + [name[0]], line_no: line_no
+            next if name[0] == 'func'
+            if BUILTIN_FUNCS.include?(name[0])
+              yield :calls, name[0], line_no: line_no
+            else
+              yield :calls, scope + [name[0]], line_no: line_no
+            end
           else
-            yield :assigns, name, line_no: line_no
+            yield :calls, name, line_no: line_no
           end
         end
-        parse_call(line, line_no, scope, &block)
-      else
-        parse_call(line, line_no, scope, &block)
       end
-    end
 
-    def self.parse_call(line, line_no, scope)
-      line.scan(FUNC_CALL) do |match|
-        name = match[0].split('.').select { |chunk| !chunk.empty? }
-        if name.length == 1
-          next if name[0] == 'func'
-          if BUILTIN_FUNCS.include?(name[0])
-            yield :calls, name[0], line_no: line_no
-          else
-            yield :calls, scope + [name[0]], line_no: line_no
+      def self.parse_def(line, line_no, scope)
+        # if it doesn't start with a valid identifier character, it's probably
+        # part of a multi-line literal and we should skip it
+        return unless line =~ /^\s*[[:alpha:]_]/
+
+        line.split.each do |var|
+          yield :defs, scope + [var.delete(',')], line_no: line_no
+          break unless var.end_with?(',')
+        end
+      end
+
+      def self.end_block(line_no, scope, stack)
+        yield :end, scope + ['}'], line_no: line_no, type: :class
+        stack.pop
+        scope.pop
+      end
+
+      def self.find_end_of_string(line, start)
+        escape = false
+        (start + 1...line.length).each do |i|
+          if escape
+            escape = false
+          elsif line[i] == '\\'
+            escape = true
+          elsif line[i] == '"'
+            return i
           end
-        else
-          yield :calls, name, line_no: line_no
         end
+
+        line.length
       end
-    end
-
-    def self.parse_def(line, line_no, scope)
-      # if it doesn't start with a valid identifier character, it's probably
-      # part of a multi-line literal and we should skip it
-      return unless line =~ /^\s*[[:alpha:]_]/
-
-      line.split.each do |var|
-        yield :defs, scope + [var.delete(',')], line_no: line_no
-        break unless var.end_with?(',')
-      end
-    end
-
-    def self.end_block(line_no, scope, stack)
-      yield :end, scope + ['}'], line_no: line_no, type: :class
-      stack.pop
-      scope.pop
-    end
-
-    def self.find_end_of_string(line, start)
-      escape = false
-      (start + 1...line.length).each do |i|
-        if escape
-          escape = false
-        elsif line[i] == '\\'
-          escape = true
-        elsif line[i] == '"'
-          return i
-        end
-      end
-
-      line.length
     end
   end
 end

--- a/lib/starscope/langs/javascript.rb
+++ b/lib/starscope/langs/javascript.rb
@@ -2,138 +2,140 @@ require 'rkelly'
 require 'babel/transpiler'
 require 'sourcemap'
 
-module Starscope::Lang
-  module Javascript
-    VERSION = 1
+module Starscope
+  module Lang
+    module Javascript
+      VERSION = 1
 
-    def self.match_file(name)
-      name.end_with?('.js')
-    end
+      def self.match_file(name)
+        name.end_with?('.js')
+      end
 
-    def self.extract(path, contents, &block)
-      return if path.end_with?('.min.js')
+      def self.extract(path, contents, &block)
+        return if path.end_with?('.min.js')
 
-      transform = Babel::Transpiler.transform(contents,
-                                              'stage' => 0,
-                                              'blacklist' => ['validation.react'],
-                                              'externalHelpers' => true,
-                                              'compact' => false,
-                                              'sourceMaps' => true)
-      map = SourceMap::Map.from_hash(transform['map'])
-      ast = RKelly::Parser.new.parse(transform['code'])
-      lines = contents.lines.to_a
+        transform = Babel::Transpiler.transform(contents,
+                                                'stage' => 0,
+                                                'blacklist' => ['validation.react'],
+                                                'externalHelpers' => true,
+                                                'compact' => false,
+                                                'sourceMaps' => true)
+        map = SourceMap::Map.from_hash(transform['map'])
+        ast = RKelly::Parser.new.parse(transform['code'])
+        lines = contents.lines.to_a
 
-      return unless ast
+        return unless ast
 
-      found = extract_methods(ast, map, lines, &block)
+        found = extract_methods(ast, map, lines, &block)
 
-      found = extract_var_decls(ast, map, lines, found, &block)
+        found = extract_var_decls(ast, map, lines, found, &block)
 
-      extract_var_reads(ast, map, lines, found, &block)
-    end
+        extract_var_reads(ast, map, lines, found, &block)
+      end
 
-    def self.extract_methods(ast, map, lines, &block)
-      found = {}
+      def self.extract_methods(ast, map, lines)
+        found = {}
 
-      ast.each do |node|
-        case node
-        when RKelly::Nodes::FunctionExprNode, RKelly::Nodes::FunctionDeclNode
-          line = find_line(node.range.from, map, lines, node.value)
+        ast.each do |node|
+          case node
+          when RKelly::Nodes::FunctionExprNode, RKelly::Nodes::FunctionDeclNode
+            line = find_line(node.range.from, map, lines, node.value)
+            next unless line
+
+            type = :func
+            type = :class if lines[line - 1].include?("class #{node.value}")
+
+            yield :defs, node.value, line_no: line, type: type
+            found[node.value] ||= Set.new
+            found[node.value].add(line)
+
+            next if type == :class
+
+            mapping = map.bsearch(SourceMap::Offset.new(node.range.to.line, node.range.to.char))
+            if lines[mapping.original.line - 1].include? '}'
+              yield :end, '}', line_no: mapping.original.line, type: type
+            else
+              yield :end, '', line_no: mapping.original.line, type: type, col: mapping.original.column
+            end
+          when RKelly::Nodes::FunctionCallNode
+            name = node_name(node.value)
+            next unless name
+
+            node = node.arguments.value[0] if name == 'require' && !node.value.is_a?(RKelly::Nodes::DotAccessorNode)
+
+            line = find_line(node.range.from, map, lines, name)
+            next unless line
+
+            found[name] ||= Set.new
+            found[name].add(line)
+
+            if name == 'require' && node.is_a?(RKelly::Nodes::StringNode)
+              yield :requires, node.value[1...-1], line_no: line
+            else
+              yield :calls, name, line_no: line
+            end
+          end
+        end
+
+        found
+      end
+
+      def self.extract_var_decls(ast, map, lines, found)
+        ast.each do |node|
+          next unless node.is_a? RKelly::Nodes::VarDeclNode
+
+          line = find_line(node.range.from, map, lines, node.name)
           next unless line
 
-          type = :func
-          type = :class if lines[line - 1].include?("class #{node.value}")
-
-          yield :defs, node.value, line_no: line, type: type
-          found[node.value] ||= Set.new
-          found[node.value].add(line)
-
-          next if type == :class
-
-          mapping = map.bsearch(SourceMap::Offset.new(node.range.to.line, node.range.to.char))
-          if lines[mapping.original.line - 1].include? '}'
-            yield :end, '}', line_no: mapping.original.line, type: type
-          else
-            yield :end, '', line_no: mapping.original.line, type: type, col: mapping.original.column
+          if node.value.is_a?(RKelly::Nodes::AssignExprNode) &&
+             node.value.value.is_a?(RKelly::Nodes::FunctionCallNode) &&
+             node.value.value.value.is_a?(RKelly::Nodes::ResolveNode) &&
+             node.value.value.value.value == 'require'
+            found[node.name] ||= Set.new
+            found[node.name].add(line)
+            next
           end
-        when RKelly::Nodes::FunctionCallNode
-          name = node_name(node.value)
-          next unless name
 
-          node = node.arguments.value[0] if name == 'require' && !node.value.is_a?(RKelly::Nodes::DotAccessorNode)
+          next if found[node.name] && found[node.name].include?(line)
+          yield :defs, node.name, line_no: line
+          found[node.name] ||= Set.new
+          found[node.name].add(line)
+        end
+
+        found
+      end
+
+      def self.extract_var_reads(ast, map, lines, found)
+        ast.each do |node|
+          name = node_name(node)
+          next unless name
 
           line = find_line(node.range.from, map, lines, name)
           next unless line
 
-          found[name] ||= Set.new
-          found[name].add(line)
-
-          if name == 'require' && node.is_a?(RKelly::Nodes::StringNode)
-            yield :requires, node.value[1...-1], line_no: line
-          else
-            yield :calls, name, line_no: line
-          end
+          next if found[name] && found[name].include?(line)
+          yield :reads, name, line_no: line
         end
       end
 
-      found
-    end
-
-    def self.extract_var_decls(ast, map, lines, found, &block)
-      ast.each do |node|
-        next unless node.is_a? RKelly::Nodes::VarDeclNode
-
-        line = find_line(node.range.from, map, lines, node.name)
-        next unless line
-
-        if node.value.is_a?(RKelly::Nodes::AssignExprNode) &&
-           node.value.value.is_a?(RKelly::Nodes::FunctionCallNode) &&
-           node.value.value.value.is_a?(RKelly::Nodes::ResolveNode) &&
-           node.value.value.value.value == 'require'
-          found[node.name] ||= Set.new
-          found[node.name].add(line)
-          next
+      def self.node_name(node)
+        case node
+        when RKelly::Nodes::DotAccessorNode
+          node.accessor
+        when RKelly::Nodes::ResolveNode
+          node.value
         end
-
-        next if found[node.name] && found[node.name].include?(line)
-        yield :defs, node.name, line_no: line
-        found[node.name] ||= Set.new
-        found[node.name].add(line)
       end
 
-      found
-    end
+      def self.find_line(from, map, lines, name)
+        mapping = map.bsearch(SourceMap::Offset.new(from.line, from.char))
+        return unless mapping
 
-    def self.extract_var_reads(ast, map, lines, found, &block)
-      ast.each do |node|
-        name = node_name(node)
-        next unless name
+        line = lines[mapping.original.line - 1]
+        return unless line.include?(name) || (name == 'require' && line.include?('import'))
 
-        line = find_line(node.range.from, map, lines, name)
-        next unless line
-
-        next if found[name] && found[name].include?(line)
-        yield :reads, name, line_no: line
+        mapping.original.line
       end
-    end
-
-    def self.node_name(node)
-      case node
-      when RKelly::Nodes::DotAccessorNode
-        node.accessor
-      when RKelly::Nodes::ResolveNode
-        node.value
-      end
-    end
-
-    def self.find_line(from, map, lines, name)
-      mapping = map.bsearch(SourceMap::Offset.new(from.line, from.char))
-      return unless mapping
-
-      line = lines[mapping.original.line - 1]
-      return unless line.include?(name) || (name == 'require' && line.include?('import'))
-
-      mapping.original.line
     end
   end
 end

--- a/lib/starscope/langs/ruby.rb
+++ b/lib/starscope/langs/ruby.rb
@@ -1,111 +1,113 @@
 require 'parser/current'
 
-module Starscope::Lang
-  module Ruby
-    VERSION = 2
+module Starscope
+  module Lang
+    module Ruby
+      VERSION = 2
 
-    def self.match_file(name)
-      return true if name.end_with?('.rb', '.rake')
-      File.open(name) do |f|
-        head = f.read(2)
-        return false if head.nil? || !head.start_with?('#!')
-        return f.readline.include?('ruby')
-      end
-    end
-
-    def self.extract(path, contents, &block)
-      ast = Parser::CurrentRuby.parse(contents)
-      extract_tree(ast, [], &block) unless ast.nil?
-    end
-
-    def self.extract_tree(tree, scope, &block)
-      extract_node(tree, scope, &block)
-
-      new_scope = []
-      if [:class, :module].include? tree.type
-        new_scope = scoped_name(tree.children[0], scope)
-        scope += new_scope
+      def self.match_file(name)
+        return true if name.end_with?('.rb', '.rake')
+        File.open(name) do |f|
+          head = f.read(2)
+          return false if head.nil? || !head.start_with?('#!')
+          return f.readline.include?('ruby')
+        end
       end
 
-      tree.children.each { |node| extract_tree(node, scope, &block) if node.is_a? AST::Node }
+      def self.extract(_path, contents, &block)
+        ast = Parser::CurrentRuby.parse(contents)
+        extract_tree(ast, [], &block) unless ast.nil?
+      end
 
-      scope.pop(new_scope.count)
-    end
+      def self.extract_tree(tree, scope, &block)
+        extract_node(tree, scope, &block)
 
-    def self.extract_node(node, scope)
-      loc = node.location
-
-      case node.type
-      when :send
-        name = scoped_name(node, scope)
-        yield :calls, name, line_no: loc.line, col: loc.column
-
-        if name.last =~ /\w+=$/
-          name[-1] = name.last.to_s.chop.to_sym
-          yield :assigns, name, line_no: loc.line, col: loc.column
-        elsif node.children[0].nil? && node.children[1] == :require && node.children[2].type == :str
-          yield :requires, node.children[2].children[0].split('/'),
-            line_no: loc.line, col: loc.column
+        new_scope = []
+        if [:class, :module].include? tree.type
+          new_scope = scoped_name(tree.children[0], scope)
+          scope += new_scope
         end
 
-      when :def
-        yield :defs, scope + [node.children[0]],
-          line_no: loc.line, type: :func, col: loc.name.column
-        yield :end, :end, line_no: loc.end.line, type: :func, col: loc.end.column
+        tree.children.each { |node| extract_tree(node, scope, &block) if node.is_a? AST::Node }
 
-      when :defs
-        yield :defs, scope + [node.children[1]],
-          line_no: loc.line, type: :func, col: loc.name.column
-        yield :end, :end, line_no: loc.end.line, type: :func, col: loc.end.column
-
-      when :module, :class
-        yield :defs, scope + scoped_name(node.children[0], scope),
-          line_no: loc.line, type: node.type, col: loc.name.column
-        yield :end, :end, line_no: loc.end.line, type: node.type, col: loc.end.column
-
-      when :casgn
-        name = scoped_name(node, scope)
-        yield :assigns, name, line_no: loc.line, col: loc.name.column
-        yield :defs, name, line_no: loc.line, col: loc.name.column
-
-      when :lvasgn, :ivasgn, :cvasgn, :gvasgn
-        yield :assigns, scope + [node.children[0]], line_no: loc.line, col: loc.name.column
-
-      when :const
-        name = scoped_name(node, scope)
-        yield :reads, name, line_no: loc.line, col: loc.name.column
-
-      when :lvar, :ivar, :cvar, :gvar
-        yield :reads, scope + [node.children[0]], line_no: loc.line, col: loc.name.column
-
-      when :sym
-        # handle `:foo` vs `foo: 1`
-        col = if loc.begin
-                loc.begin.column + 1
-              else
-                loc.expression.column
-              end
-        yield :sym, [node.children[0]], line_no: loc.line, col: col
+        scope.pop(new_scope.count)
       end
-    end
 
-    def self.scoped_name(node, scope)
-      if node.type == :block
-        scoped_name(node.children[0], scope)
-      elsif [:lvar, :ivar, :cvar, :gvar, :const, :send, :casgn].include? node.type
-        if node.children[0].is_a? Symbol
-          [node.children[0]]
-        elsif node.children[0].is_a? AST::Node
-          scoped_name(node.children[0], scope) << node.children[1]
-        elsif node.children[0].nil?
-          if node.type == :const
-            [node.children[1]]
-          else
-            scope + [node.children[1]]
+      def self.extract_node(node, scope)
+        loc = node.location
+
+        case node.type
+        when :send
+          name = scoped_name(node, scope)
+          yield :calls, name, line_no: loc.line, col: loc.column
+
+          if name.last =~ /\w+=$/
+            name[-1] = name.last.to_s.chop.to_sym
+            yield :assigns, name, line_no: loc.line, col: loc.column
+          elsif node.children[0].nil? && node.children[1] == :require && node.children[2].type == :str
+            yield :requires, node.children[2].children[0].split('/'),
+              line_no: loc.line, col: loc.column
           end
+
+        when :def
+          yield :defs, scope + [node.children[0]],
+            line_no: loc.line, type: :func, col: loc.name.column
+          yield :end, :end, line_no: loc.end.line, type: :func, col: loc.end.column
+
+        when :defs
+          yield :defs, scope + [node.children[1]],
+            line_no: loc.line, type: :func, col: loc.name.column
+          yield :end, :end, line_no: loc.end.line, type: :func, col: loc.end.column
+
+        when :module, :class
+          yield :defs, scope + scoped_name(node.children[0], scope),
+            line_no: loc.line, type: node.type, col: loc.name.column
+          yield :end, :end, line_no: loc.end.line, type: node.type, col: loc.end.column
+
+        when :casgn
+          name = scoped_name(node, scope)
+          yield :assigns, name, line_no: loc.line, col: loc.name.column
+          yield :defs, name, line_no: loc.line, col: loc.name.column
+
+        when :lvasgn, :ivasgn, :cvasgn, :gvasgn
+          yield :assigns, scope + [node.children[0]], line_no: loc.line, col: loc.name.column
+
+        when :const
+          name = scoped_name(node, scope)
+          yield :reads, name, line_no: loc.line, col: loc.name.column
+
+        when :lvar, :ivar, :cvar, :gvar
+          yield :reads, scope + [node.children[0]], line_no: loc.line, col: loc.name.column
+
+        when :sym
+          # handle `:foo` vs `foo: 1`
+          col = if loc.begin
+                  loc.begin.column + 1
+                else
+                  loc.expression.column
+                end
+          yield :sym, [node.children[0]], line_no: loc.line, col: col
         end
-      else
-        [node.type]
+      end
+
+      def self.scoped_name(node, scope)
+        if node.type == :block
+          scoped_name(node.children[0], scope)
+        elsif [:lvar, :ivar, :cvar, :gvar, :const, :send, :casgn].include? node.type
+          if node.children[0].is_a? Symbol
+            [node.children[0]]
+          elsif node.children[0].is_a? AST::Node
+            scoped_name(node.children[0], scope) << node.children[1]
+          elsif node.children[0].nil?
+            if node.type == :const
+              [node.children[1]]
+            else
+              scope + [node.children[1]]
+            end
+          end
+        else
+          [node.type]
+        end
       end
     end
   end

--- a/lib/starscope/output.rb
+++ b/lib/starscope/output.rb
@@ -1,47 +1,49 @@
 require 'ruby-progressbar'
 
-class Starscope::Output
-  PBAR_FORMAT = '%t: %c/%C %E ||%b>%i||'.freeze
+module Starscope
+  class Output
+    PBAR_FORMAT = '%t: %c/%C %E ||%b>%i||'.freeze
 
-  def initialize(level, out = STDOUT)
-    @out = out
-    @level = level
-    @pbar = nil
-  end
+    def initialize(level, out = STDOUT)
+      @out = out
+      @level = level
+      @pbar = nil
+    end
 
-  def new_pbar(title, num_items)
-    return if @level == :quiet
-    @pbar = ProgressBar.create(title: title, total: num_items,
-                               format: PBAR_FORMAT, length: 80,
-                               out: @out)
-  end
+    def new_pbar(title, num_items)
+      return if @level == :quiet
+      @pbar = ProgressBar.create(title: title, total: num_items,
+                                 format: PBAR_FORMAT, length: 80,
+                                 out: @out)
+    end
 
-  def inc_pbar
-    @pbar.increment if @pbar
-  end
+    def inc_pbar
+      @pbar.increment if @pbar
+    end
 
-  def finish_pbar
-    @pbar.finish if @pbar
-    @pbar = nil
-  end
+    def finish_pbar
+      @pbar.finish if @pbar
+      @pbar = nil
+    end
 
-  def extra(msg)
-    return unless @level == :verbose
-    output(msg)
-  end
+    def extra(msg)
+      return unless @level == :verbose
+      output(msg)
+    end
 
-  def normal(msg)
-    return if @level == :quiet
-    output(msg)
-  end
+    def normal(msg)
+      return if @level == :quiet
+      output(msg)
+    end
 
-  private
+    private
 
-  def output(msg)
-    if @pbar
-      @pbar.log(msg)
-    else
-      @out.puts msg
+    def output(msg)
+      if @pbar
+        @pbar.log(msg)
+      else
+        @out.puts msg
+      end
     end
   end
 end

--- a/lib/starscope/queryable.rb
+++ b/lib/starscope/queryable.rb
@@ -1,46 +1,48 @@
 require 'starscope/matcher'
 
-module Starscope::Queryable
-  def query(tables, value, filters = {})
-    tables = [tables] if tables.is_a?(Symbol)
-    tables.each { |t| raise Starscope::DB::NoTableError, "Table '#{t}' not found" unless @tables[t] }
-    input = Enumerator.new do |y|
-      tables.each do |t|
-        @tables[t].each do |elem|
-          y << elem
+module Starscope
+  module Queryable
+    def query(tables, value, filters = {})
+      tables = [tables] if tables.is_a?(Symbol)
+      tables.each { |t| raise Starscope::DB::NoTableError, "Table '#{t}' not found" unless @tables[t] }
+      input = Enumerator.new do |y|
+        tables.each do |t|
+          @tables[t].each do |elem|
+            y << elem
+          end
         end
+      end
+
+      run_query(value, input, filters)
+    end
+
+    private
+
+    def run_query(query, input, filters)
+      query = Starscope::Matcher.new(query)
+      filters.each { |k, v| filters[k] = Starscope::Matcher.new(v) }
+
+      results = input.select { |x| filter(x, filters) }.group_by { |x| match(x, query) }
+
+      Starscope::Matcher::MATCH_TYPES.each do |type|
+        next if results[type].nil? || results[type].empty?
+        return results[type]
+      end
+
+      []
+    end
+
+    def filter(record, filters)
+      filters.all? do |key, filter|
+        target = record[key] || (@meta[:files][record[:file]] || {})[key]
+        target && filter.match(target.to_s)
       end
     end
 
-    run_query(value, input, filters)
-  end
+    def match(record, query)
+      name = record[:name].map(&:to_s).join('::')
 
-  private
-
-  def run_query(query, input, filters)
-    query = Starscope::Matcher.new(query)
-    filters.each { |k, v| filters[k] = Starscope::Matcher.new(v) }
-
-    results = input.select { |x| filter(x, filters) }.group_by { |x| match(x, query) }
-
-    Starscope::Matcher::MATCH_TYPES.each do |type|
-      next if results[type].nil? || results[type].empty?
-      return results[type]
+      query.match(name)
     end
-
-    []
-  end
-
-  def filter(record, filters)
-    filters.all? do |key, filter|
-      target = record[key] || (@meta[:files][record[:file]] || {})[key]
-      target && filter.match(target.to_s)
-    end
-  end
-
-  def match(record, query)
-    name = record[:name].map(&:to_s).join('::')
-
-    query.match(name)
   end
 end

--- a/starscope.gemspec
+++ b/starscope.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry', '~> 0.10.1'
   gem.add_development_dependency 'minitest', '~> 5.8'
   gem.add_development_dependency 'mocha', '~> 1.1'
-  gem.add_development_dependency 'rubocop', '~> 0.37.0'
+  gem.add_development_dependency 'rubocop', '~> 0.39.0'
 end

--- a/test/unit/fragment_extractor_test.rb
+++ b/test/unit/fragment_extractor_test.rb
@@ -1,7 +1,12 @@
 require_relative '../test_helper'
 
 describe Starscope::FragmentExtractor do
-  module ::Starscope::Lang::Dummy; end
+  module Starscope
+    module Lang
+      module Dummy
+      end
+    end
+  end
 
   before do
     @extractor = Starscope::FragmentExtractor.new(


### PR DESCRIPTION
- Upgrade rubocop version.
- Exclude the sample fixture from all cops unconditionally.
- Enable unused-method-argument and class-and-module-children.

Major whitespace changes here but nothing functional.