### PR TITLE
ctags: fix export to other directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 Trunk
 --------------------
 
-No changes yet.
+Bug Fixes:
+ * Fix exporting ctags files to different output directories (#163).
 
 v1.5.3 (2016-03-02)
 --------------------

--- a/test/unit/exportable_test.rb
+++ b/test/unit/exportable_test.rb
@@ -8,12 +8,25 @@ describe Starscope::Exportable do
   end
 
   it 'must export to ctags' do
-    @db.export_to(:ctags, @buf)
+    @db.export_to(:ctags, @buf, '.')
     @buf.rewind
     lines = @buf.each_line.to_a
     lines.must_include(
       "NoTableError\t" \
-      "#{FIXTURES}/sample_ruby.rb\t" \
+      "./#{FIXTURES}/sample_ruby.rb\t" \
+      "/^  class NoTableError < StandardError; end$/;\"\t" \
+      "kind:c\t" \
+      "language:Ruby\n"
+    )
+  end
+
+  it 'must export to ctags with different path prefixes' do
+    @db.export_to(:ctags, @buf, '../foo')
+    @buf.rewind
+    lines = @buf.each_line.to_a
+    lines.must_include(
+      "NoTableError\t" \
+      "../foo/#{FIXTURES}/sample_ruby.rb\t" \
       "/^  class NoTableError < StandardError; end$/;\"\t" \
       "kind:c\t" \
       "language:Ruby\n"
@@ -21,7 +34,7 @@ describe Starscope::Exportable do
   end
 
   it 'must export to cscope' do
-    @db.export_to(:cscope, @buf)
+    @db.export_to(:cscope, @buf, '.')
     @buf.rewind
     lines = @buf.each_line.to_a
 


### PR DESCRIPTION
The way ctags files are structured, the paths in them always have to be relative
to the location of the tag file, not your project root. Starscope needs to
respect that when exporting ctags files to other directories via
`--export ctags,some/path/to/somewhere/else/tags`.

@kriansa

Fixes #163.