### PR TITLE
ruby: fix parsing with invalid literal encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Trunk
 --------------------
 
 Bug Fixes:
+ * Fix parsing ruby files with invalidly-encoded literals (#160).
  * Fix exporting ctags files to different output directories (#163).
 
 v1.5.3 (2016-03-02)

--- a/test/fixtures/sample_ruby.rb
+++ b/test/fixtures/sample_ruby.rb
@@ -8,6 +8,7 @@ LANGS = [
 
 class Starscope::DB
   PBAR_FORMAT = '%t: %c/%C %E ||%b>%i||'.freeze
+  SOME_INVALID_ENCODING = "\xff"
 
   class NoTableError < StandardError; end
 

--- a/test/unit/exportable_test.rb
+++ b/test/unit/exportable_test.rb
@@ -42,7 +42,7 @@ describe Starscope::Exportable do
     lines.must_include "\tgSunday\n"
     lines.must_include "\t`add_file\n"
     lines.must_include "\t}}\n"
-    lines.must_include "12 class \n"
+    lines.must_include "13 class \n"
 
     lines.wont_include "= [\n"
     lines.wont_include "4 LANGS = [\n"


### PR DESCRIPTION
Per https://github.com/whitequark/parser/issues/283 the upstream parser gem will
blow up on these by default; suppress that diagnostic since the actual ruby
syntax is probably still well-formed and we want the tokens (we don't really
care about the contents of string literals).

Fixes #160.