### PR TITLE
Read/write db in binary file mode

### DIFF
--- a/lib/starscope/db.rb
+++ b/lib/starscope/db.rb
@@ -56,7 +56,7 @@ module Starscope
 
       @meta[:langs].merge!(LANGS)
 
-      File.open(filename, 'w') do |file|
+      File.open(filename, 'wb') do |file|
         Zlib::GzipWriter.wrap(file) do |stream|
           stream.puts DB_FORMAT
           stream.puts Oj.dump @meta
@@ -148,7 +148,7 @@ module Starscope
     private
 
     def open_db(filename)
-      File.open(filename, 'r') do |file|
+      File.open(filename, 'rb') do |file|
         begin
           Zlib::GzipReader.wrap(file) do |stream|
             parse_db(stream)

--- a/lib/starscope/exportable.rb
+++ b/lib/starscope/exportable.rb
@@ -19,7 +19,7 @@ module Starscope
 
       @output.normal("Exporting to '#{path}' in format '#{format}'...")
       path_prefix = Pathname.getwd.relative_path_from(Pathname.new(path).dirname.expand_path)
-      File.open(path, 'w') do |file|
+      File.open(path, 'wb') do |file|
         export_to(format, file, path_prefix)
       end
       @output.normal('Export complete.')


### PR DESCRIPTION
This fixes starscope to work at all on Windows (avoids auto-CRLF conversion) but should not affect other OSes.