### PR TITLE
Fix handling of __ENCODING__ in ruby

### DIFF
--- a/lib/starscope/langs/ruby.rb
+++ b/lib/starscope/langs/ruby.rb
@@ -90,7 +90,16 @@ module Starscope
 
         when :const
           name = scoped_name(node, scope)
-          yield :reads, name, line_no: loc.line, col: loc.name.column
+          # handle `__ENCODING__` and other weird quasi-constants
+          column = case loc
+                   when Parser::Source::Map::Constant
+                     loc.name.column
+                   when Parser::Source::Map
+                     loc.column
+                   when nil
+                     return
+                   end
+          yield :reads, name, line_no: loc.line, col: column
 
         when :lvar, :ivar, :cvar, :gvar
           yield :reads, scope + [node.children[0]], line_no: loc.line, col: loc.name.column

--- a/test/fixtures/sample_ruby.rb
+++ b/test/fixtures/sample_ruby.rb
@@ -162,3 +162,5 @@ class Starscope::DB
     end
   end
 end
+
+puts __ENCODING__


### PR DESCRIPTION
It parses weirdly. This might be an upstream parser issue really, but we
can handle it for now.

@Tikkoneus thanks for pointing this one out. Feel free to point out any other specific parse errors that should be fixed.