### PR TITLE
Look for .starscope.json in current dir before falling back to home folder.

### DIFF
--- a/bin/starscope
+++ b/bin/starscope
@@ -9,7 +9,7 @@ require 'readline'
 require 'starscope'
 
 DEFAULT_DB = '.starscope.db'.freeze
-CONFIG_FILE = File.join(Dir.home, '.starscope.json')
+CONFIG_FILE = File.exist?('.starscope.json') ? '.starscope.json' : File.join(Dir.home, '.starscope.json')
 GLOBAL_CONFIG = File.exist?(CONFIG_FILE) ? Oj.load_file(CONFIG_FILE, symbol_keys: true) : {}
 
 options = { read: true,

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -109,14 +109,17 @@ Excluded patterns are also remembered, and can be added at any time. If an
 existing file in the database matches a newly added exclusion rule, it will be
 removed.
 
-For commonly excluded files you can create a `~/.starscope.json` file with
-contents like:
+You can exclude files on a per-directory basis by creating a `.starscope.json`
+file in a given directory with contents like:
 ```json
 {
-  "excludes": ["foo", "bar"]
+  "excludes": ["foo", "bar/", "**/*.ext"]
 }
 ```
-Patterns listed there will be excluded from all starscope databases by default.
+
+For commonly excluded files you can create a home directory config file at 
+`~/.starscope.json`. Patterns listed there will be excluded from all starscope 
+databases by default.
 
 Queries
 -------


### PR DESCRIPTION
This PR supports configuring a `.starscope.json` on a per-directory basis. This resolves https://github.com/eapache/starscope/issues/180.